### PR TITLE
Docs(CommandHistory): Fix UG case inconsistency

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -275,7 +275,7 @@ Format: `idel INDEX`
 Example:
 * `idel 1` Deletes the 1st issue.
 
-### View Command History : `history`
+### View command history : `history`
 
 Displays the user's valid command history, sorted from most to least recent.
 
@@ -302,7 +302,7 @@ Exits the program.
 
 Format: `exit`
 
-### Access Command History
+### Access command history
 
 Previous successful commands can be accessed via the UP and DOWN arrow keys on the keyboard. UP selects the previous command. DOWN selects the next command.
 


### PR DESCRIPTION
## What this does
Closes #129 

## How to test
1. `cd` to `docs/` folder of project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted user guide in your browser (default address: http://127.0.0.1:4000/UserGuide.html).
4. Look at the `View command history` and `Access command history` entries. They should follow the case formatting of the other entries.

