### PR TITLE
Update rooms prevent set occupancy

### DIFF
--- a/src/main/java/seedu/address/logic/commands/room/AddRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/AddRoomCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands.room;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_OCCUPANCY_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TYPE;
 
@@ -19,12 +18,10 @@ public class AddRoomCommand extends Command {
             + "Parameters: "
             + PREFIX_ROOM_NUMBER + "NAME "
             + PREFIX_ROOM_TYPE + "TYPE "
-            + PREFIX_ROOM_OCCUPANCY_STATUS + "OCCUPANCY STATUS "
             + "[" + PREFIX_ROOM_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_ROOM_NUMBER + "12-123 "
             + PREFIX_ROOM_TYPE + "CORRIDOR_AC "
-            + PREFIX_ROOM_OCCUPANCY_STATUS + "Y "
             + PREFIX_ROOM_TAG + "SHN";
 
     public static final String MESSAGE_SUCCESS = "New room added: %1$s";

--- a/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
@@ -2,7 +2,6 @@ package seedu.address.logic.commands.room;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_OCCUPANCY_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TYPE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ROOMS;
@@ -39,11 +38,9 @@ public class EditRoomCommand extends Command {
             + "Parameters: INDEX (must be a positive integer) "
             + "[" + PREFIX_ROOM_NUMBER + "NAME] "
             + "[" + PREFIX_ROOM_TYPE + "TYPE] "
-            + "[" + PREFIX_ROOM_OCCUPANCY_STATUS + "OCCUPANCY STATUS] "
             + "[" + PREFIX_ROOM_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_ROOM_NUMBER + "12-100 "
-            + PREFIX_ROOM_OCCUPANCY_STATUS + "y";
+            + PREFIX_ROOM_NUMBER + "12-100 ";
 
     public static final String MESSAGE_EDIT_ROOM_SUCCESS = "Edited Room: %1$s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
@@ -94,7 +91,7 @@ public class EditRoomCommand extends Command {
 
         RoomNumber updatedRoomNumber = editRoomDescriptor.getRoomNumber().orElse(roomToEdit.getRoomNumber());
         RoomType updatedRoomType = editRoomDescriptor.getRoomType().orElse(roomToEdit.getRoomType());
-        IsOccupied updatedIsOccupied = editRoomDescriptor.getIsOccupied().orElse(roomToEdit.isOccupied());
+        IsOccupied updatedIsOccupied = roomToEdit.isOccupied();
         Set<Tag> updatedTags = editRoomDescriptor.getTags().orElse(roomToEdit.getTags());
 
         return new Room(updatedRoomNumber, updatedRoomType, updatedIsOccupied, updatedTags);
@@ -146,7 +143,7 @@ public class EditRoomCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(roomNumber, roomType, isOccupied, tags);
+            return CollectionUtil.isAnyNonNull(roomNumber, roomType, tags);
         }
 
         public void setRoomNumber(RoomNumber roomNumber) {

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,7 +15,6 @@ public class CliSyntax {
 
     public static final Prefix PREFIX_ROOM_NUMBER = new Prefix("r/");
     public static final Prefix PREFIX_ROOM_TYPE = new Prefix("t/");
-    public static final Prefix PREFIX_ROOM_OCCUPANCY_STATUS = new Prefix("o/");
     public static final Prefix PREFIX_ROOM_TAG = new Prefix("g/");
 
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");

--- a/src/main/java/seedu/address/logic/parser/room/AddRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/AddRoomCommandParser.java
@@ -2,7 +2,6 @@ package seedu.address.logic.parser.room;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_OCCUPANCY_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TYPE;
 
@@ -16,7 +15,6 @@ import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.room.IsOccupied;
 import seedu.address.model.room.Room;
 import seedu.address.model.room.RoomNumber;
 import seedu.address.model.room.RoomType;
@@ -36,21 +34,20 @@ public class AddRoomCommandParser implements Parser<AddRoomCommand> {
     @Override
     public AddRoomCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_ROOM_NUMBER, PREFIX_ROOM_TYPE, PREFIX_ROOM_OCCUPANCY_STATUS,
+                ArgumentTokenizer.tokenize(args, PREFIX_ROOM_NUMBER, PREFIX_ROOM_TYPE,
                         PREFIX_ROOM_TAG);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_ROOM_NUMBER, PREFIX_ROOM_TYPE, PREFIX_ROOM_OCCUPANCY_STATUS)
+        if (!arePrefixesPresent(argMultimap, PREFIX_ROOM_NUMBER, PREFIX_ROOM_TYPE)
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRoomCommand.MESSAGE_USAGE));
         }
 
         RoomNumber roomNumber = ParserUtil.parseRoomNumber(argMultimap.getValue(PREFIX_ROOM_NUMBER).get());
         RoomType roomType = ParserUtil.parseRoomType(argMultimap.getValue(PREFIX_ROOM_TYPE).get());
-        IsOccupied roomOccupancyStatus =
-                ParserUtil.parseRoomOccupancyStatus(argMultimap.getValue(PREFIX_ROOM_OCCUPANCY_STATUS).get());
+
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_ROOM_TAG));
 
-        Room room = new Room(roomNumber, roomType, roomOccupancyStatus, tagList);
+        Room room = new Room(roomNumber, roomType, tagList);
 
         return new AddRoomCommand(room);
     }

--- a/src/main/java/seedu/address/logic/parser/room/EditRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/EditRoomCommandParser.java
@@ -3,7 +3,6 @@ package seedu.address.logic.parser.room;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_OCCUPANCY_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TYPE;
 
@@ -36,8 +35,7 @@ public class EditRoomCommandParser implements Parser<EditRoomCommand> {
     public EditRoomCommand parse(String userInput) throws ParseException {
         requireNonNull(userInput);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(userInput, PREFIX_ROOM_NUMBER, PREFIX_ROOM_TYPE,
-                        PREFIX_ROOM_OCCUPANCY_STATUS, PREFIX_ROOM_TAG);
+                ArgumentTokenizer.tokenize(userInput, PREFIX_ROOM_NUMBER, PREFIX_ROOM_TYPE, PREFIX_ROOM_TAG);
 
         Index index;
 
@@ -55,10 +53,6 @@ public class EditRoomCommandParser implements Parser<EditRoomCommand> {
         if (argMultimap.getValue(PREFIX_ROOM_TYPE).isPresent()) {
             editRoomDescriptor
                     .setRoomType(ParserUtil.parseRoomType(argMultimap.getValue(PREFIX_ROOM_TYPE).get()));
-        }
-        if (argMultimap.getValue(PREFIX_ROOM_OCCUPANCY_STATUS).isPresent()) {
-            editRoomDescriptor.setIsOccupied(ParserUtil.parseRoomOccupancyStatus(argMultimap
-                            .getValue(PREFIX_ROOM_OCCUPANCY_STATUS).get()));
         }
 
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_ROOM_TAG)).ifPresent(editRoomDescriptor::setTags);

--- a/src/main/java/seedu/address/model/room/Room.java
+++ b/src/main/java/seedu/address/model/room/Room.java
@@ -15,6 +15,11 @@ import seedu.address.model.tag.Tag;
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
 public class Room {
+    // Rooms have a default occupancy status of "No". Occupancy
+    // can only be edited through the allocation/deallocation commands
+    // or through the reading of the model from a JSON file (which isn't
+    // really editing, its just model creation)
+    public static final String DEFAULT_OCCUPANCY_STATUS = "N";
     // Identity fields
     // Room number, type, occupancy status, tags
     private final RoomNumber roomNumber;
@@ -23,13 +28,26 @@ public class Room {
     private final Set<Tag> tags = new HashSet<>();
 
     /**
-     * Every field must be present and not null.
+     * Every field must be present and not null. This constructor should only be used when creating
+     * a room model from the JSON file. The Add/Edit room commands and their respective parsers should
+     * NOT use this constructor. Use the one that does not take in isOccupied.
      */
     public Room(RoomNumber roomNumber, RoomType roomType, IsOccupied isOccupied, Set<Tag> tags) {
         requireAllNonNull(roomNumber, roomType, isOccupied, tags);
         this.roomNumber = roomNumber;
         this.roomType = roomType;
         this.isOccupied = isOccupied;
+        this.tags.addAll(tags);
+    }
+
+    /**
+     * Every field must be present and not null.
+     */
+    public Room(RoomNumber roomNumber, RoomType roomType, Set<Tag> tags) {
+        requireAllNonNull(roomNumber, roomType, tags);
+        this.roomNumber = roomNumber;
+        this.roomType = roomType;
+        this.isOccupied = new IsOccupied(DEFAULT_OCCUPANCY_STATUS);
         this.tags.addAll(tags);
     }
 

--- a/src/test/java/seedu/address/logic/commands/room/EditRoomCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/room/EditRoomCommandTest.java
@@ -35,14 +35,21 @@ public class EditRoomCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredRoomList_success() {
-        Room editedRoom = new RoomBuilder().build();
+        Room roomToEdit = model.getFilteredRoomList().get(0);
+
+        // Room we are changing to needs to maintain the occupancy status
+        // of the room we start with. So we pre-set it here.
+        Room editedRoom = new RoomBuilder()
+                .withOccupancyStatus(roomToEdit.isOccupied().toString())
+                .build();
+
         EditRoomDescriptor descriptor = new EditRoomDescriptorBuilder(editedRoom).build();
         EditRoomCommand editRoomCommand = new EditRoomCommand(INDEX_FIRST, descriptor);
 
         String expectedMessage = String.format(EditRoomCommand.MESSAGE_EDIT_ROOM_SUCCESS, editedRoom);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setRoom(model.getFilteredRoomList().get(0), editedRoom);
+        expectedModel.setRoom(roomToEdit, editedRoom);
 
         assertCommandSuccess(editRoomCommand, model, expectedMessage, expectedModel);
     }

--- a/src/test/java/seedu/address/logic/commands/room/EditRoomDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/room/EditRoomDescriptorTest.java
@@ -45,12 +45,6 @@ public class EditRoomDescriptorTest {
                 .build();
         assertFalse(VALID_ROOM_DESCRIPTOR_ONE.equals(editedOne));
 
-        // different occupancy -> return false
-        editedOne = new EditRoomDescriptorBuilder(VALID_ROOM_DESCRIPTOR_ONE)
-                .withOccupancyStatus("n")
-                .build();
-        assertFalse(VALID_ROOM_DESCRIPTOR_ONE.equals(editedOne));
-
         // different tags -> return false
         editedOne = new EditRoomDescriptorBuilder(VALID_ROOM_DESCRIPTOR_ONE)
                 .withTags(VALID_ROOM_TAGS)

--- a/src/test/java/seedu/address/logic/commands/room/RoomCommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/room/RoomCommandTestUtil.java
@@ -41,21 +41,17 @@ public class RoomCommandTestUtil {
         // 15-312, corridor non ac, not occupied
         VALID_ROOM_DESCRIPTOR_ONE = new EditRoomDescriptorBuilder().withRoomNumber(VALID_ROOM_NUMBER_ONE)
                 .withRoomType(VALID_ROOM_TYPES.get(0))
-                .withOccupancyStatus(VALID_ROOM_OCCUPANCIES.get(0))
                 .build();
 
         // 12-322, corridor ac, occupied
         VALID_ROOM_DESCRIPTOR_TWO = new EditRoomDescriptorBuilder().withRoomNumber(VALID_ROOM_NUMBER_TWO)
                 .withRoomType(VALID_ROOM_TYPES.get(1))
-                .withOccupancyStatus(VALID_ROOM_OCCUPANCIES.get(1))
                 .build();
 
         // Random build based on valid parameters
         VALID_ROOM_DESCRIPTOR_RANDOM = new EditRoomDescriptorBuilder().withRoomNumber(VALID_ROOM_NUMBER_THREE)
                 // Pick a random valid room type, there are only 4
                 .withRoomType(VALID_ROOM_TYPES.get(random.nextInt(VALID_ROOM_TYPES.size())))
-                // Pick a random valid occupancy of yes or no
-                .withOccupancyStatus(VALID_ROOM_OCCUPANCIES.get(random.nextInt(VALID_ROOM_OCCUPANCIES.size())))
                 .build();
     }
 

--- a/src/test/java/seedu/address/testutil/room/EditRoomDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/room/EditRoomDescriptorBuilder.java
@@ -5,7 +5,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.room.EditRoomCommand.EditRoomDescriptor;
-import seedu.address.model.room.IsOccupied;
 import seedu.address.model.room.Room;
 import seedu.address.model.room.RoomNumber;
 import seedu.address.model.room.RoomType;
@@ -49,14 +48,6 @@ public class EditRoomDescriptorBuilder {
      */
     public EditRoomDescriptorBuilder withRoomType(String roomType) {
         descriptor.setRoomType(new RoomType(roomType));
-        return this;
-    }
-
-    /**
-     * Sets the {@code IsOccupied} of the {@code EditRoomDescriptorBuilder} that we are building.
-     */
-    public EditRoomDescriptorBuilder withOccupancyStatus(String isOccupied) {
-        descriptor.setIsOccupied(new IsOccupied(isOccupied));
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/room/RoomBuilder.java
+++ b/src/test/java/seedu/address/testutil/room/RoomBuilder.java
@@ -16,7 +16,7 @@ import seedu.address.model.util.SampleDataUtil;
 public class RoomBuilder {
     public static final String DEFAULT_ROOM_NUMBER = "01-001";
     public static final String DEFAULT_ROOM_TYPE = "CORRIDOR_NON_AC";
-    public static final String DEFAULT_OCCUPANCY_STATUS = "y";
+    public static final String DEFAULT_OCCUPANCY_STATUS = "N";
 
     private RoomNumber roomNumber;
     private RoomType type;

--- a/src/test/java/seedu/address/testutil/room/RoomUtil.java
+++ b/src/test/java/seedu/address/testutil/room/RoomUtil.java
@@ -1,9 +1,7 @@
 package seedu.address.testutil.room;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_OCCUPANCY_STATUS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TYPE;
 
@@ -32,7 +30,6 @@ public class RoomUtil {
         StringBuilder sb = new StringBuilder();
         sb.append(PREFIX_ROOM_NUMBER + room.getRoomNumber().roomNumber + " ");
         sb.append(PREFIX_ROOM_TYPE + room.getRoomType().value.toString() + " ");
-        sb.append(PREFIX_ROOM_OCCUPANCY_STATUS + room.isOccupied().toString() + " ");
         room.getTags().stream().forEach(
             s -> sb.append(PREFIX_ROOM_TAG + s.tagName + " ")
         );
@@ -48,8 +45,6 @@ public class RoomUtil {
                 .ifPresent(roomNumber -> sb.append(PREFIX_ROOM_NUMBER + roomNumber.roomNumber + " "));
         descriptor.getRoomType()
                 .ifPresent(roomType -> sb.append(PREFIX_PHONE).append(roomType.value.toString()).append(" "));
-        descriptor.getIsOccupied()
-                .ifPresent(isOccupied -> sb.append(PREFIX_EMAIL).append(isOccupied.toString()).append(" "));
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {


### PR DESCRIPTION
### What this does
Blocks access to editing occupancy status of rooms or adding rooms with a specified occupancy status through the GUI. All relevant tests have been updated too.

### How to test
1. Run SunRez
2. Try to add a room with the occupancy status set (`o/y` or `o/n`). It should throw an error
3. Try to add a room without the occupancy status set. It should work
4. Try to edit that same room by setting an occupancy status as you did in step 2. It should not work
5. Remove the occupancy status. The edit should go through.

### What is left
Updating the UG and DG