### PR TITLE
Fix(Redit): Fix bug where year of resident can't be edited

### DIFF
--- a/src/main/java/seedu/address/logic/commands/resident/EditResidentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/resident/EditResidentCommand.java
@@ -151,7 +151,7 @@ public class EditResidentCommand extends Command {
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, room);
+            return CollectionUtil.isAnyNonNull(name, phone, email, year, room);
         }
 
         public void setName(Name name) {


### PR DESCRIPTION
Fixes #141 

## Steps to reproduce
Launch SunRez
Run clear
Run radd n/John Doe p/98765432 e/johnd@example.com y/1 r/01-234
Run redit 1 y/2

## Expected Behavior
John Doe's year should be updated to 2.

## Actual Behavior
"At least one field to edit must be provided."