### PR TITLE
Fix(room): Display room occupancy status in a more readable way

### DIFF
--- a/src/main/java/seedu/address/ui/RoomCard.java
+++ b/src/main/java/seedu/address/ui/RoomCard.java
@@ -42,7 +42,7 @@ public class RoomCard extends UiPart<Region> {
         id.setText(displayedIndex + ". ");
         roomNumber.setText(room.getRoomNumber().roomNumber);
         roomType.setText(room.getRoomType().value.toString());
-        isOccupied.setText(room.isOccupied().toString());
+        isOccupied.setText(room.isOccupied().isOccupied ? "Occupied" : "Not Occupied");
         room.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));


### PR DESCRIPTION
### What this does:

- Displays room occupancy in a more readable way, using "Occupied" and "Not Occupied" instead of "Y" and "N"

Closes #143 

### How to test:

1. Launch SunRez and add a room if there are none
2. Occupancy should be displayed as  "Occupied" and "Not Occupied" instead of "Y" and "N"