### PR TITLE
144 ug block edit del allocated rooms

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -144,7 +144,7 @@ Example:
 Adds a room to the housing management system.
 
 Format: `oadd r/ROOM_NO t/TYPE [g/TAG]`
-* Room is initialised with default occupancy status of "No"
+* Room is initialised with default occupancy status of "No".
 * Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. The occupancy status cannot be defaulted to "Yes" during room addition.
 
 Example:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -144,6 +144,8 @@ Example:
 Adds a room to the housing management system.
 
 Format: `oadd r/ROOM_NO t/TYPE [g/TAG]`
+* Room is initialised with default occupancy status of "No"
+* Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. The occupancy status cannot be defaulted to "Yes" during room addition.
 
 Example:
 * `oadd r/10-112 t/corridor_ac g/SHN` Adds a room numbered `10-112` of type `corridor_ac` with the tag `SHN`.
@@ -183,6 +185,7 @@ Format: `oedit INDEX [r/ROOM_NO] [t/TYPE] [g/TAG]`
 * `INDEX` refers to the index number shown in the displayed room list. `INDEX` **must be a positive integer 1, 2, 3, …**.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
+* Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. The occupancy status is not controllable through the `oedit` command. 
 * `oedit` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before making further edits.
 
 Example:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -441,7 +441,7 @@ Action | Format, Examples
 **Find residents** | `rfind KEYWORD [MORE_KEYWORDS]` <br> e.g. `rfind bob bobby`
 **Edit a resident record** | `redit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [r/ROOM]` <br> e.g. `redit 1 p/91234567 e/e0123456@u.nus.edu`
 **Delete a resident** |  `rdel INDEX` <br> e.g. `rdel 1`
-**Add a room** |  `oadd r/ROOM_NO t/TYPE [g/TAG]` <br> e.g. `oadd n/17-101 t/corridor_ac o/Y g/SHN`
+**Add a room** |  `oadd r/ROOM_NO t/TYPE [g/TAG]` <br> e.g. `oadd n/17-101 t/corridor_ac g/SHN`
 **List all rooms** |  `olist`
 **Find rooms** |  `ofind KEYWORD [MORE_KEYWORDS]` <br> e.g. `ofind 10- 15-`
 **Edit a room record** |  `oedit INDEX [r/ROOM_NO] [t/TYPE] [g/TAG]` <br> e.g. `oedit 1 g/SHN`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -143,10 +143,10 @@ Example:
 
 Adds a room to the housing management system.
 
-Format: `oadd r/ROOM_NO t/TYPE o/OCCUPATION_STATUS [g/TAG]`
+Format: `oadd r/ROOM_NO t/TYPE [g/TAG]`
 
 Example:
-* `oadd r/10-112 t/corridor_ac o/Y g/SHN` Adds a room numbered `10-112` of type `corridor_ac` with the tag `SHN` and occupation status `Y(es)`.
+* `oadd r/10-112 t/corridor_ac g/SHN` Adds a room numbered `10-112` of type `corridor_ac` with the tag `SHN`.
 
 
 ### List all rooms : `olist`
@@ -179,13 +179,14 @@ Examples:
 
 Edits the existing room record at a specified index.
 
-Format: `oedit INDEX [r/ROOM_NO] [t/TYPE] [o/OCCUPATION_STATUS] [g/TAG]`
+Format: `oedit INDEX [r/ROOM_NO] [t/TYPE] [g/TAG]`
 * `INDEX` refers to the index number shown in the displayed room list. `INDEX` **must be a positive integer 1, 2, 3, …**.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
+* `oedit` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before making further edits.
 
 Example:
-* `oedit 1 o/Y g/SHN` Edits the status of the 1st room and tag to be `Occupied` and `Y` respectively.
+* `oedit 1 g/SHN g/Blue` Edits the 1st room's tags to be to `SHN` and `Blue`.
 
 
 ### Delete a room : `odel`
@@ -194,6 +195,7 @@ Deletes the room at a specified index.
 
 Format: `odel INDEX`
 * `INDEX` refers to the index number shown in the displayed resident list. `INDEX` **must be a positive integer 1,2,3, ...**.
+* `odel` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before attempting to delete the room.
 
 Example:
 * `odel 1` Deletes the 1st room in the room list.
@@ -439,10 +441,10 @@ Action | Format, Examples
 **Find residents** | `rfind KEYWORD [MORE_KEYWORDS]` <br> e.g. `rfind bob bobby`
 **Edit a resident record** | `redit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [r/ROOM]` <br> e.g. `redit 1 p/91234567 e/e0123456@u.nus.edu`
 **Delete a resident** |  `rdel INDEX` <br> e.g. `rdel 1`
-**Add a room** |  `oadd r/ROOM_NO t/TYPE o/OCCUPATION_STATUS [g/TAG]` <br> e.g. `oadd n/17-101 t/corridor_ac o/Y g/SHN`
+**Add a room** |  `oadd r/ROOM_NO t/TYPE [g/TAG]` <br> e.g. `oadd n/17-101 t/corridor_ac o/Y g/SHN`
 **List all rooms** |  `olist`
 **Find rooms** |  `ofind KEYWORD [MORE_KEYWORDS]` <br> e.g. `ofind 10- 15-`
-**Edit a room record** |  `oedit INDEX [r/ROOM_NO] [t/TYPE] [g/TAG] [o/OCCUPATION_STATUS]` <br> e.g. `oedit 1 o/Y`
+**Edit a room record** |  `oedit INDEX [r/ROOM_NO] [t/TYPE] [g/TAG]` <br> e.g. `oedit 1 g/SHN`
 **Delete a room** | `odel INDEX` <br> e.g. `odel 1`
 **Allocate a Resident to Room** | `alloc n/NAME r/ROOM_NO` <br> e.g. `alloc n/John Tan r/03-100` 
 **Deallocate a Resident from Room** | `dealloc n/NAME r/ROOM_NO` <br> e.g. `dealloc n/John Tan r/03-100`


### PR DESCRIPTION
### What this does:
Updates the behaviour for `oadd`, `oedit` and `odel` to reflect the following changes:
1. Updating of occupancy status is no longer allowed through oadd or edit.
2. `oedit` and `odel` are blocked if the rooms are currently allocated to a resident.

Closes #144 

### How to test

1. cd to docs/ folder of project.
2. Run bundle exec jekyll serve.
3. Open the jekyll-hosted user guide in your browser (default address: http://127.0.0.1:4000/UserGuide.html).
4. Look at the Add Room, Edit Room and Delete Room entries. They should reflect the above changes in an easy to read and clear way, without any ambiguity.