### PR TITLE
Fix error message for duplicate issue

### DIFF
--- a/src/main/java/seedu/address/logic/commands/issue/AddIssueCommand.java
+++ b/src/main/java/seedu/address/logic/commands/issue/AddIssueCommand.java
@@ -38,7 +38,7 @@ public class AddIssueCommand extends Command {
             + PREFIX_TAG + "HIGH";
 
     public static final String MESSAGE_SUCCESS = "New issue added: %1$s";
-    public static final String MESSAGE_DUPLICATE_ISSUE = "This isue already exists in SunRez";
+    public static final String MESSAGE_DUPLICATE_ISSUE = "This issue already exists in SunRez";
 
     private final Issue toAdd;
 


### PR DESCRIPTION
## What this does
1. Fixes the error message when adding duplicate issues


## How to test
1. Launch SunRez
2. Execute `iadd r/10-100 d/Broken light t/2020/01/12 3:30pm s/pending c/furniture g/HIGH`
3. Execute the same command again
4. There should be an error message "This issue already exists in SunRez"