### PR TITLE
Fix(UndoRedo): Fix some stateful commands not being undoable

### DIFF
--- a/src/main/java/seedu/address/logic/commands/issue/CloseIssueCommand.java
+++ b/src/main/java/seedu/address/logic/commands/issue/CloseIssueCommand.java
@@ -51,7 +51,7 @@ public class CloseIssueCommand extends Command {
         }
 
         model.closeIssue(issueToClose);
-
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_CLOSE_ISSUE_SUCCESS, issueToClose));
     }
 

--- a/src/main/java/seedu/address/logic/commands/residentroom/AllocateResidentRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/residentroom/AllocateResidentRoomCommand.java
@@ -82,6 +82,7 @@ public class AllocateResidentRoomCommand extends Command {
 
         // Set ResidentRoom
         model.addResidentRoom(toAllocate);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, toAllocate));
     }
 

--- a/src/main/java/seedu/address/logic/commands/residentroom/DeallocateResidentRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/residentroom/DeallocateResidentRoomCommand.java
@@ -57,6 +57,7 @@ public class DeallocateResidentRoomCommand extends Command {
         setRoomToUnoccupied(residentToDeallocate, model);
 
         model.deleteResidentRoom(residentRoomToDeallocate);
+        model.commitAddressBook();
         return new CommandResult(String.format(MESSAGE_SUCCESS, residentRoomToDeallocate));
     }
 


### PR DESCRIPTION
## What this does
This PR fixes the following commands to be undoable: `alloc`, `dealloc`, `iclo`.

Fixes #168 
Fixes #169 
Fixes #170

## How to test
1. Launch SunRez
2. Execute each of the three commands above
3. Try to undo/redo each of them. The undo/redo functionality should work as expected