### PR TITLE
Fix tags being removed when closed

### DIFF
--- a/src/main/java/seedu/address/model/issue/Issue.java
+++ b/src/main/java/seedu/address/model/issue/Issue.java
@@ -52,7 +52,7 @@ public class Issue implements Comparable<Issue> {
                 issue.getTimestamp(),
                 new Status(IssueStatus.Closed),
                 issue.getCategory(),
-                new HashSet<Tag>());
+                issue.getTags());
     }
 
     public RoomNumber getRoomNumber() {


### PR DESCRIPTION
## What this does
This PR:
1. Stops tags from being deleted when closing an issue with `iclo`

## How to test
1. Create a pending issue with tags e.g. `iadd r/10-100 d/Broken room g/Room g/Window`
2. Close the issue with `iclo`
3. The issue should still have the tags