### PR TITLE
Fix(Room): Show better error msg when index is negative in ofind/odel

### DIFF
--- a/src/main/java/seedu/address/logic/parser/room/DeleteRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/DeleteRoomCommandParser.java
@@ -18,12 +18,7 @@ public class DeleteRoomCommandParser implements Parser<DeleteRoomCommand> {
      */
     @Override
     public DeleteRoomCommand parse(String userInput) throws ParseException {
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(userInput);
-        } catch (ParseException pe) {
-            throw pe;
-        }
+        Index index = ParserUtil.parseIndex(userInput);
         return new DeleteRoomCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/room/DeleteRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/DeleteRoomCommandParser.java
@@ -1,7 +1,5 @@
 package seedu.address.logic.parser.room;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.room.DeleteRoomCommand;
 import seedu.address.logic.parser.Parser;
@@ -20,12 +18,12 @@ public class DeleteRoomCommandParser implements Parser<DeleteRoomCommand> {
      */
     @Override
     public DeleteRoomCommand parse(String userInput) throws ParseException {
+        Index index;
         try {
-            Index index = ParserUtil.parseIndex(userInput);
-            return new DeleteRoomCommand(index);
+            index = ParserUtil.parseIndex(userInput);
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteRoomCommand.MESSAGE_USAGE), pe);
+            throw pe;
         }
+        return new DeleteRoomCommand(index);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/room/EditRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/EditRoomCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser.room;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TAG;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ROOM_TYPE;
@@ -42,7 +41,7 @@ public class EditRoomCommandParser implements Parser<EditRoomCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditRoomCommand.MESSAGE_USAGE), pe);
+            throw pe;
         }
 
         EditRoomDescriptor editRoomDescriptor = new EditRoomDescriptor();

--- a/src/main/java/seedu/address/logic/parser/room/EditRoomCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/room/EditRoomCommandParser.java
@@ -38,11 +38,8 @@ public class EditRoomCommandParser implements Parser<EditRoomCommand> {
 
         Index index;
 
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw pe;
-        }
+        index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
 
         EditRoomDescriptor editRoomDescriptor = new EditRoomDescriptor();
         if (argMultimap.getValue(PREFIX_ROOM_NUMBER).isPresent()) {


### PR DESCRIPTION
### What this does:
- Shows a clearer error message when indices are negative vs out of range
- Closes #165 

### How to test:
- Run `oedit` or `odel` with a negative index. Expect to see "Index is not a non-zero unsigned integer." 
- Previously, it would just show the command usage. Ensure that is not the case now.