### PR TITLE
Fix(Sort): Sort residents by alphabetical order

### DIFF
--- a/src/main/java/seedu/address/model/resident/Name.java
+++ b/src/main/java/seedu/address/model/resident/Name.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Resident's name in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidName(String)}
  */
-public class Name {
+public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
@@ -61,4 +61,8 @@ public class Name {
         return fullName.hashCode();
     }
 
+    @Override
+    public int compareTo(Name o) {
+        return fullName.compareTo(o.fullName);
+    }
 }

--- a/src/main/java/seedu/address/model/resident/Resident.java
+++ b/src/main/java/seedu/address/model/resident/Resident.java
@@ -8,7 +8,7 @@ import java.util.Objects;
  * Represents a Resident in the address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Resident {
+public class Resident implements Comparable<Resident> {
 
     // Identity fields
     private final Name name;
@@ -106,4 +106,8 @@ public class Resident {
         return builder.toString();
     }
 
+    @Override
+    public int compareTo(Resident r) {
+        return name.compareTo(r.name);
+    }
 }

--- a/src/main/java/seedu/address/model/resident/UniqueResidentList.java
+++ b/src/main/java/seedu/address/model/resident/UniqueResidentList.java
@@ -55,6 +55,7 @@ public class UniqueResidentList implements Iterable<Resident> {
             throw new DuplicateResidentException();
         }
         internalList.add(toAdd);
+        FXCollections.sort(internalList);
     }
 
     /**
@@ -75,6 +76,7 @@ public class UniqueResidentList implements Iterable<Resident> {
         }
 
         internalList.set(index, editedResident);
+        FXCollections.sort(internalList);
     }
 
     /**
@@ -86,11 +88,13 @@ public class UniqueResidentList implements Iterable<Resident> {
         if (!internalList.remove(toRemove)) {
             throw new ResidentNotFoundException();
         }
+        FXCollections.sort(internalList);
     }
 
     public void setResidents(UniqueResidentList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        FXCollections.sort(internalList);
     }
 
     /**
@@ -104,6 +108,7 @@ public class UniqueResidentList implements Iterable<Resident> {
         }
 
         internalList.setAll(residents);
+        FXCollections.sort(internalList);
     }
 
     /**


### PR DESCRIPTION
### What this does
Closes #203 
Closes #232 

### How to test
`clear`
`radd n/Zender Doe p/98765432 e/johnd@example.com y/1`
`radd n/John Doe p/98765432 e/johnd@example.com y/1`
`radd n/Aaron Doe p/98765432 e/johnd@example.com y/1`
`radd n/Charles Doe p/98765432 e/johnd@example.com y/1`

The residents listed should be sorted alphabetically.