### PR TITLE
Fix #219: Remove room no. from radd and redit

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -600,11 +600,11 @@ If your changes to the data file makes its format invalid, SunRez will discard a
 Action | Format, Examples
 --------|------------------
 **Show help** | `help`
-**Add a resident** | `radd n/NAME p/PHONE_NUMBER e/EMAIL y/YEAR` <br> e.g. `radd n/Joseph Tan p/84666774 e/e0103994@u.nus.edu y/2 r/01-234`
+**Add a resident** | `radd n/NAME p/PHONE_NUMBER e/EMAIL y/YEAR` <br> e.g. `radd n/Joseph Tan p/84666774 e/e0103994@u.nus.edu y/2`
 **List all residents** | `rlist`
 **List all unallocated residents** | `rulist`
 **Find residents** | `rfind KEYWORD [MORE_KEYWORDS]` <br> e.g. `rfind bob bobby`
-**Edit a resident record** | `redit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL] [r/ROOM_NUMBER]` <br> e.g. `redit 1 p/91234567 e/e0123456@u.nus.edu`
+**Edit a resident record** | `redit INDEX [n/NAME] [p/PHONE_NUMBER] [e/EMAIL]` <br> e.g. `redit 1 p/91234567 e/e0123456@u.nus.edu`
 **Delete a resident** |  `rdel INDEX` <br> e.g. `rdel 1`
 **Add a room** |  `oadd r/ROOM_NUMBER t/ROOM_TYPE [g/TAG]` <br> e.g. `oadd n/17-101 t/corridor_ac g/SHN`
 **List all rooms** |  `olist`


### PR DESCRIPTION
## What this does
Fixes #219 
Also removes `[r/ROOM_NUMBER]` from command summary of `redit`

## How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Check that the UG has the changes listed above