### PR TITLE
Close #244: Add TAG parameter specifications

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -135,10 +135,14 @@ DESCRIPTION OF PARAMETER
 
 
 #### `TAG`
-DESCRIPTION OF PARAMETER
-* FORMAT AND RESTRICTIONS WITH JUSTIFICATION
-* (if applicable) For best usage, ...
-* (if applicable) Valid examples (if not clear from above)
+The tag associated with a room or issue.
+* Tags must be non-blank and alphanumeric (spaces are not allowed).
+* Tags are limited to 25 characters.
+* Tags are case-sensitive: e.g. `SHN`,`shn` and `Shn` are each considered separate tags.
+* Duplicate tags will be accepted as input, but only one instance will be recorded.
+* For the best experience, we recommend keeping tags short and having fewer than 20 of them per entry. There is no 
+  theoretical limit to the number of tags an entry can have, but SunRez may slow down or run into unexpected problems 
+  for a huge number of tags.
 
 
 #### `TIMESTAMP`


### PR DESCRIPTION
## What this does
Add TAG parameter specifications to UG.

Closes #244 

## How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Check the TAG subsection of the command parameter section of the UG

## What needs to be done
Link relevant commands to this subsection.