### PR TITLE
Fix #266: Indicate that insertion order of tags do not guarantee any sort of display order

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -140,6 +140,7 @@ The tag associated with a room or issue.
 * Tags must be non-blank and alphanumeric (spaces are not allowed).
 * Tags are limited to 25 characters.
 * Tags are case-sensitive: e.g. `SHN`,`shn` and `Shn` are each considered separate tags.
+* Insertion order of tags does not guarantee display order in any part of the user interface.
 * Duplicate tags will be accepted as input, but only one instance will be recorded.
 * For the best experience, we recommend keeping tags short and having fewer than 20 of them per entry. There is no 
   theoretical limit to the number of tags an entry can have, but SunRez may slow down or run into unexpected problems 


### PR DESCRIPTION
### What this does:
This indicates that the insertion order of tags does not guarantee any sort of display order in the UG. This fixes #266 by addressing the tester's concerns.

### How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Navigate to the Tags subsection of Command Parameters and observe that Tag behaviour is documented accurately. 