### PR TITLE
Fix #210: Fix typo in Add/Edit room command's usage message

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -256,6 +256,10 @@ Example:
 
 ### Room Management
 
+<div markdown="block" class="alert alert-info">
+**:information_source: Rooms are always sorted in ascending order by room number in all views**
+</div>
+
 #### Add a room : `oadd`
 
 Adds a room to the housing management system.

--- a/src/main/java/seedu/address/logic/commands/room/AddRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/AddRoomCommand.java
@@ -16,7 +16,7 @@ public class AddRoomCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a room to SunRez. "
             + "Parameters: "
-            + PREFIX_ROOM_NUMBER + "NAME "
+            + PREFIX_ROOM_NUMBER + "ROOM_NUMBER "
             + PREFIX_ROOM_TYPE + "TYPE "
             + "[" + PREFIX_ROOM_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
@@ -37,7 +37,7 @@ public class EditRoomCommand extends Command {
             + "by the index number used in the displayed room list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_ROOM_NUMBER + "NAME] "
+            + "[" + PREFIX_ROOM_NUMBER + "ROOM_NUMBER] "
             + "[" + PREFIX_ROOM_TYPE + "TYPE] "
             + "[" + PREFIX_ROOM_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "

--- a/src/main/java/seedu/address/model/room/Room.java
+++ b/src/main/java/seedu/address/model/room/Room.java
@@ -14,7 +14,8 @@ import seedu.address.model.tag.Tag;
  * Represents a Room in the hostel management system.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-public class Room {
+
+public class Room implements Comparable<Room> {
     // Rooms have a default occupancy status of "No". Occupancy
     // can only be edited through the allocation/deallocation commands
     // or through the reading of the model from a JSON file (which isn't
@@ -125,4 +126,8 @@ public class Room {
         return builder.toString();
     }
 
+    @Override
+    public int compareTo(Room room) {
+        return this.roomNumber.compareTo(room.getRoomNumber());
+    }
 }

--- a/src/main/java/seedu/address/model/room/RoomNumber.java
+++ b/src/main/java/seedu/address/model/room/RoomNumber.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents a Room's number in the address book.
  * Guarantees: immutable; is valid as declared in {@link #isValidRoomNumber(String)}
  */
-public class RoomNumber {
+public class RoomNumber implements Comparable<RoomNumber> {
     public static final String MESSAGE_CONSTRAINTS =
             "Room numbers should only contain positive integers and dashes, and it should not be blank";
 
@@ -57,5 +57,10 @@ public class RoomNumber {
     @Override
     public int hashCode() {
         return roomNumber.hashCode();
+    }
+
+    @Override
+    public int compareTo(RoomNumber roomNumber) {
+        return this.roomNumber.compareTo(roomNumber.roomNumber);
     }
 }

--- a/src/main/java/seedu/address/model/room/UniqueRoomList.java
+++ b/src/main/java/seedu/address/model/room/UniqueRoomList.java
@@ -54,6 +54,7 @@ public class UniqueRoomList implements Iterable<Room> {
             throw new DuplicateRoomException();
         }
         internalList.add(toAdd);
+        FXCollections.sort(internalList);
     }
 
     /**
@@ -74,6 +75,7 @@ public class UniqueRoomList implements Iterable<Room> {
         }
 
         internalList.set(index, editedRoom);
+        FXCollections.sort(internalList);
     }
 
     /**
@@ -85,11 +87,13 @@ public class UniqueRoomList implements Iterable<Room> {
         if (!internalList.remove(toRemove)) {
             throw new RoomNotFoundException();
         }
+        FXCollections.sort(internalList);
     }
 
     public void setRooms(UniqueRoomList replacement) {
         requireNonNull(replacement);
         internalList.setAll(replacement.internalList);
+        FXCollections.sort(internalList);
     }
 
     /**
@@ -103,6 +107,7 @@ public class UniqueRoomList implements Iterable<Room> {
         }
 
         internalList.setAll(rooms);
+        FXCollections.sort(internalList);
     }
 
     /**


### PR DESCRIPTION
### What this does

Closes #210 by fixing a typo in Add/Edit room command's usage message

### How to test

1. Run SunRez
2. Type `oadd` and see if `NAME` is removed
3. Check EditRoomCommand's code to see if `NAME` is removed. This cannot be tested visually due to recently discovered bug #293 