### PR TITLE
Fix #236: Fix typo in Add/Edit Room cmd usage message

### DIFF
--- a/src/main/java/seedu/address/logic/commands/room/AddRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/AddRoomCommand.java
@@ -16,7 +16,7 @@ public class AddRoomCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a room to SunRez. "
             + "Parameters: "
-            + PREFIX_ROOM_NUMBER + "NAME "
+            + PREFIX_ROOM_NUMBER + "ROOM_NUMBER "
             + PREFIX_ROOM_TYPE + "TYPE "
             + "[" + PREFIX_ROOM_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
@@ -37,7 +37,7 @@ public class EditRoomCommand extends Command {
             + "by the index number used in the displayed room list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_ROOM_NUMBER + "NAME] "
+            + "[" + PREFIX_ROOM_NUMBER + "ROOM_NUMBER] "
             + "[" + PREFIX_ROOM_TYPE + "TYPE] "
             + "[" + PREFIX_ROOM_TAG + "TAG]...\n"
             + "Example: " + COMMAND_WORD + " 1 "


### PR DESCRIPTION
### What this does

Closes #210 by fixing a typo in Add/Edit room command's usage message

### How to test

1. Run SunRez
2. Type `oadd` and see if `NAME` is removed
3. Check EditRoomCommand's code to see if `NAME` is removed. This cannot be tested visually due to recently discovered bug #293