### PR TITLE
Fix #236: Prevent room deletion if there are issues associated with it

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -342,7 +342,8 @@ Deletes the room at a specified index.
 
 Format: `odel INDEX`
 * `INDEX` refers to the index number shown in the displayed resident list. `INDEX` **must be a positive integer 1,2,3, ...**.
-* `odel` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before attempting to delete the room.
+* `odel` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before attempting to delete the room. See [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info.
+* `odel` will be blocked if the there are issues associated with the room. Run `idel` to delete all issues associated the room before attempting to delete the room. See [delete an issue](#delete-an-issue--idel) for more info.
 
 Parameters:
 * [INDEX](#index) The index of the room to delete.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -34,7 +34,8 @@ Commands in this user guide follow this format:
 * Parameters can be in any order.<br>
   e.g. if the command specifies `n/NAME p/PHONE_NUMBER`, `p/PHONE_NUMBER n/NAME` is also acceptable.
 
-* If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence of the parameter will be taken.<br>
+* If a parameter is expected only once in the command, but you specified it multiple times, only the last occurrence 
+  of the parameter will be taken.<br>
   e.g. if you specify `n/John Doe n/Jane Doe`, only `n/Jane Doe` will be taken.
 
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `ilist`, `exit` and `clear`) will be ignored.<br>
@@ -53,7 +54,8 @@ The resident's name will take the **later** occurrence of name and create a resi
 
 On the other hand, **all** [tags](#tag) specified will be taken. 
 
-For instance, `radd n/John Doe n/Timmy Tan p/91234567 e/e0123456@u.nus.edu y/3 g/tag_one g/tag_two g/tag_three` will create a resident with tags `tag_one`, `tag_two` and `tag_three`.
+For instance, `radd n/John Doe n/Timmy Tan p/91234567 e/e0123456@u.nus.edu y/3 g/tag_one g/tag_two g/tag_three` will 
+create a resident with tags `tag_one`, `tag_two` and `tag_three`.
 
 
 #### Interpreting parameter values
@@ -63,7 +65,8 @@ For example, if you key in this command:
 
 `radd n/John Doe p/91234567 e/e0123456@u.nus.edu y/3`
 
-The resident's name will be all characters that follows `n/` until just before the start of `p/`, including the space. Most commands, however, trim leading and trailing spaces.
+The resident's name will be all characters that follows `n/` until just before the start of `p/`, including the space. 
+Most commands, however, trim leading and trailing spaces.
 
 Let us break this down further and assume `radd` only takes in 2 parameters for the purposes of explanation. 
 We can break the command down as follows:
@@ -72,7 +75,8 @@ We can break the command down as follows:
 
 A user can enter a `NAME_STRING` that consists of anything, including text that contains prefix-like strings such as `s/`. 
 For example, a user could enter `John s/o Tom`. 
-However, as `s/` is not a valid prefix for the `radd` command, the command parser will treat `John s/o Tom` as the value for the name parameter. 
+However, as `s/` is not a valid prefix for the `radd` command, the command parser will treat `John s/o Tom` as the 
+value for the name parameter. 
 
 
 The validation for the `Name` parameter will process `John s/o Tom` and may reject it based on the stated validation rules.
@@ -80,9 +84,11 @@ However, a known limitation of this approach is that parameter values containing
 
 Let us take a look at another example:
 
-If `NAME_STRING` = `John p/ Tom`, the command keyed in could look like `radd p/[VALID_PHONE_NUM] n/John p/ Tom` (Remember that prefix order does not matter.) 
+If `NAME_STRING` = `John p/ Tom`, the command keyed in could look like `radd p/[VALID_PHONE_NUM] n/John p/ Tom` 
+(Remember that prefix order does not matter.) 
 
-This will create the presence of 2 phone number parameters. In such a case, the latter value will be taken. As `Tom` is not a valid phone number, it will be rejected.
+This will create the presence of 2 phone number parameters. In such a case, the latter value will be taken. 
+As `Tom` is not a valid phone number, it will be rejected.
 
 
 ### Command Parameters
@@ -213,15 +219,18 @@ The year of study of a resident.
 
 3. Copy the file to the folder you want to use as the _home folder_ for your SunRez.
 
-4. Double-click the file to start the app. A GUI like the one pictured below should appear in a few seconds. Note how the app contains some sample data.<br>
+4. Double-click the file to start the app. A GUI like the one pictured below should appear in a few seconds. 
+   Note how the app contains some sample data.<br>
    ![Ui](images/Ui.png)
 
-5. Type a command in the command box and press Enter to execute it. e.g. typing **`help`** and pressing Enter will open the help window.<br>
+5. Type a command in the command box and press Enter to execute it. 
+   e.g. typing **`help`** and pressing Enter will open the help window.<br>
    Some example commands you can try:
 
     * **`rlist`** : Lists all residents.
 
-    * **`radd`**`n/Joseph Tan p/84666774 e/e0103994@u.nus.edu y/2` : Adds a resident named `Joseph Tan` with phone number `84666774`, email `e0103994@u.nus.edu`, a 2nd year student.
+    * **`radd`**`n/Joseph Tan p/84666774 e/e0103994@u.nus.edu y/2` : 
+      Adds a resident named `Joseph Tan` with phone number `84666774`, email `e0103994@u.nus.edu`, a 2nd year student.
 
     * **`rdel`**`3` : Deletes the 3rd resident shown in the current resident list.
 
@@ -250,7 +259,9 @@ Parameters:
 * [YEAR](#year) The year of the resident.
 
 Examples:
-* `radd n/John Doe p/91234567 e/e0123456@u.nus.edu y/3` Adds a resident named `John Doe` with phone number `91234567`, email `e0123456@u.nus.edu`, and as a 3rd year student, without any room allocated.
+* `radd n/John Doe p/91234567 e/e0123456@u.nus.edu y/3` 
+  Adds a resident named `John Doe` with phone number `91234567`, email `e0123456@u.nus.edu`, and as a 3rd year student, 
+  without any room allocated.
 
 
 #### List all residents : `rlist`
@@ -294,7 +305,8 @@ Parameters:
 * [YEAR](#year) The year of the resident.
 
 Example:
-* `redit 1 p/91234567 e/e0123456@u.nus.edu` Edits the phone number and email address of the 1st resident to be `91234567` and `e0123456@u.nus.edu` respectively.
+* `redit 1 p/91234567 e/e0123456@u.nus.edu` Edits the phone number and email address of the 1st resident to 
+  be `91234567` and `e0123456@u.nus.edu` respectively.
 
 
 #### Delete a resident : `rdel`
@@ -329,7 +341,8 @@ Adds a room to the housing management system.
 Format: `oadd r/ROOM_NUMBER t/ROOM_TYPE [g/TAG]`
 * Room is initialised with default occupancy status of "No".
 * The occupancy status cannot be defaulted to "Yes" during room addition.
-* Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. See [allocate a resident](#allocate-resident-to-room-alloc) or [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info. 
+* Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. 
+  See [allocate a resident](#allocate-resident-to-room-alloc) or [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info. 
   
 Parameters:
 * [ROOM_NUMBER](#room_number) The room number of the room to add.
@@ -353,7 +366,8 @@ Finds all rooms by room number or tag that contain any of the given keywords.
 
 Format: `ofind KEYWORD [MORE_KEYWORDS]`
 * The search matches any part of the room number. e.g. `10` will match `10-111` and `14-101`.
-* The search for tags matches any part of the tag and is NOT case-sensitive. e.g `mell`, `smell`, `smelly` or `room` all work to match `smellyroom`. `s` will match both `smellyroom` and `SHN`.
+* The search for tags matches any part of the tag and is NOT case-sensitive. e.g `mell`, `smell`, `smelly` or `room` 
+  all work to match `smellyroom`. `s` will match both `smellyroom` and `SHN`.
 * The order of the keywords does not matter. e.g. `11- 10-` will match `10-100`, `10-101`, `11-100`, and `11-101`.
 * Only the room number and tags are searched.
 * Rooms matching at least one keyword will be returned (i.e. OR search). e.g. `10 20` will return `10-100`, `11-120`.
@@ -379,7 +393,8 @@ Format: `oedit INDEX [r/ROOM_NUMBER] [t/ROOM_TYPE] [g/TAG]`
 * Existing values will be updated to the input values.
 * `oedit` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before making further edits.
 * The occupancy status is not controllable through the `oedit` command.
-* Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. See [allocate a resident](#allocate-resident-to-room-alloc) or [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info.
+* Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. 
+  See [allocate a resident](#allocate-resident-to-room-alloc) or [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info.
 
 
 Parameters:
@@ -398,8 +413,11 @@ Deletes the room at a specified index.
 
 Format: `odel INDEX`
 * `INDEX` refers to the index number shown in the displayed resident list. `INDEX` **must be a positive integer 1,2,3, ...**.
-* `odel` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before attempting to delete the room.
-  See [Deallocate a resident](#deallocate-resident-from-room--dealloc).
+* `odel` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before attempting to delete the room. 
+  See [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info.
+* `odel` will be blocked if the there are issues associated with the room. 
+  Run `idel` to delete all issues associated the room before attempting to delete the room. 
+  See [delete an issue](#delete-an-issue--idel) for more info.
 
 Parameters:
 * [INDEX](#index) The index of the room to delete.
@@ -453,7 +471,8 @@ Adds an issue to the housing management system.
 Format: `iadd r/ROOM_NUMBER d/DESCRIPTION [t/TIMESTAMP] [s/STATUS] [c/CATEGORY] [g/TAG]`
 
 Example:
-* `iadd r/10-100 d/Broken light c/Furniture` Creates an issue for room number `10-100` with description `Broken light` under the category `Furniture`.
+* `iadd r/10-100 d/Broken light c/Furniture` 
+  Creates an issue for room number `10-100` with description `Broken light` under the category `Furniture`.
 
 
 #### List all issues : `ilist`
@@ -470,10 +489,12 @@ Finds all issues that contain any of the given keywords in the description, room
 Format: `ifind KEYWORD [MORE_KEYWORDS]`
 * The search is case-insensitive. e.g. `broken` will match `Broken`.
 * The order of the keywords does not matter. e.g. `Broken light` will match `light broken`.
-* The search for tags and description matches any part of the tag and is NOT case-sensitive. e.g `high`, `HIGH` or `h` all work to match `High`. `H` will match both `Hot` and `High`.
+* The search for tags and description matches any part of the tag and is NOT case-sensitive. 
+  e.g `high`, `HIGH` or `h` all work to match `High`. `H` will match both `Hot` and `High`.
 * The search matches any part of the room number. e.g. `10` will match `10-111` and `14-101`.
 * Only the description, room number, and tags are searched.
-* Issues matching at least one keyword will be returned (i.e. OR search). e.g. `Broken window` will return `Broken light`, `Dirty window`, and `Broken window`.
+* Issues matching at least one keyword will be returned (i.e. OR search). 
+  e.g. `Broken window` will return `Broken light`, `Dirty window`, and `Broken window`.
 
 Examples:
 * `ifind chair` returns `Broken chair` and `Chair missing wheel`.

--- a/src/main/java/seedu/address/logic/commands/room/DeleteRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/DeleteRoomCommand.java
@@ -27,6 +27,8 @@ public class DeleteRoomCommand extends Command {
     public static final String MESSAGE_DELETE_ROOM_SUCCESS = "Deleted room: %1$s";
     public static final String MESSAGE_ROOM_ALLOCATED_FAILURE =
             "The room has been allocated to another resident. Please deallocate the room before deletion.";
+    public static final String MESSAGE_ROOM_HAS_ISSUES = "This room still has issues assigned to it. Please delete all "
+            + "corresponding issues before deleting the room.";
 
     private final Index targetIndex;
 
@@ -47,6 +49,10 @@ public class DeleteRoomCommand extends Command {
 
         if (model.hasEitherResidentRoom(new ResidentRoom(null, roomToDelete.getRoomNumber()))) {
             throw new CommandException(MESSAGE_ROOM_ALLOCATED_FAILURE);
+        }
+
+        if (model.issuesContainRoom(roomToDelete)) {
+            throw new CommandException(MESSAGE_ROOM_HAS_ISSUES);
         }
 
         model.deleteRoom(roomToDelete);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -26,6 +26,7 @@ public class AddressBook implements ReadOnlyAddressBook {
     private final UniqueRoomList rooms;
     private final UniqueResidentRoomList residentRooms;
     private final IssueList issues;
+
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
@@ -258,6 +259,16 @@ public class AddressBook implements ReadOnlyAddressBook {
         issues.remove(key);
     }
 
+    /**
+     * Checks if any issues have the given room associated with it
+     *
+     * @param target Room to check if it has issues associated with it.
+     * @return true if there are issues with the given room associated with it
+     */
+    public boolean issuesContainRoom(Room target) {
+        return issues.containsRoom(target);
+    }
+
     //// util methods
 
     @Override
@@ -292,9 +303,9 @@ public class AddressBook implements ReadOnlyAddressBook {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof AddressBook // instanceof handles nulls
-                        && residents.equals(((AddressBook) other).residents)
-                        && rooms.equals(((AddressBook) other).rooms)
-                        && issues.equals(((AddressBook) other).issues));
+                && residents.equals(((AddressBook) other).residents)
+                && rooms.equals(((AddressBook) other).rooms)
+                && issues.equals(((AddressBook) other).issues));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -266,7 +266,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Checks if any issues have the given room associated with it
      *
      * @param target Room to check if it has issues associated with it.
-     * @return True if there are issues with the given room associated with it
+     * @return True if there are issues with the given room associated with it.
      */
     public boolean issuesContainRoom(Room target) {
         return issues.containsRoom(target);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -266,7 +266,7 @@ public class AddressBook implements ReadOnlyAddressBook {
      * Checks if any issues have the given room associated with it
      *
      * @param target Room to check if it has issues associated with it.
-     * @return true if there are issues with the given room associated with it
+     * @return True if there are issues with the given room associated with it
      */
     public boolean issuesContainRoom(Room target) {
         return issues.containsRoom(target);

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -225,7 +225,7 @@ public interface Model {
      * Checks if any issues have the given room associated with it
      *
      * @param target Room to check if it has issues associated with it.
-     * @return true if there are issues with the given room associated with it
+     * @return True if there are issues with the given room associated with it
      */
     boolean issuesContainRoom(Room target);
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -225,7 +225,7 @@ public interface Model {
      * Checks if any issues have the given room associated with it
      *
      * @param target Room to check if it has issues associated with it.
-     * @return True if there are issues with the given room associated with it
+     * @return True if there are issues with the given room associated with it.
      */
     boolean issuesContainRoom(Room target);
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -20,7 +20,9 @@ import seedu.address.model.room.RoomNumber;
  * The API of the Model component.
  */
 public interface Model {
-    /** {@code Predicate} that always evaluate to true */
+    /**
+     * {@code Predicate} that always evaluate to true
+     */
     Predicate<Resident> PREDICATE_SHOW_ALL_RESIDENTS = unused -> true;
     Predicate<Room> PREDICATE_SHOW_ALL_ROOMS = unused -> true;
     Predicate<Issue> PREDICATE_SHOW_ALL_ISSUES = unused -> true;
@@ -59,6 +61,7 @@ public interface Model {
     void setAddressBookFilePath(Path addressBookFilePath);
 
     // =========== AddressBook ================================================================================
+
     /**
      * Replaces address book data with the data in {@code addressBook}.
      */
@@ -219,6 +222,14 @@ public interface Model {
     void closeIssue(Issue target);
 
     /**
+     * Checks if any issues have the given room associated with it
+     *
+     * @param target Room to check if it has issues associated with it.
+     * @return true if there are issues with the given room associated with it
+     */
+    boolean issuesContainRoom(Room target);
+
+    /**
      * Returns an unmodifiable view of the filtered issue list.
      */
     ObservableList<Issue> getFilteredIssueList();
@@ -232,6 +243,7 @@ public interface Model {
     void updateFilteredIssueList(Predicate<Issue> predicate);
 
     // =========== ResidentRoom =============================================================
+
     /**
      * Returns true if a residentroom with the same identity as {@code residentRoom} exists in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -44,7 +44,7 @@ public class ModelManager implements Model {
      * Initializes a ModelManager with the given addressBook, userPrefs and commandHistory.
      */
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs,
-            ReadOnlyCommandHistory commandHistory) {
+                        ReadOnlyCommandHistory commandHistory) {
         super();
         requireAllNonNull(addressBook, userPrefs, commandHistory);
 
@@ -332,6 +332,12 @@ public class ModelManager implements Model {
 
         setIssue(target, closedIssue);
     }
+
+    @Override
+    public boolean issuesContainRoom(Room target) {
+        return statefulAddressBook.issuesContainRoom(target);
+    }
+
 
     // =========== Filtered Issue List Accessors =============================================================
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -45,7 +45,7 @@ public class ModelManager implements Model {
      * Initializes a ModelManager with the given addressBook, userPrefs and commandHistory.
      */
     public ModelManager(ReadOnlyAddressBook addressBook, ReadOnlyUserPrefs userPrefs,
-                        ReadOnlyCommandHistory commandHistory) {
+        ReadOnlyCommandHistory commandHistory) {
         super();
         requireAllNonNull(addressBook, userPrefs, commandHistory);
 

--- a/src/main/java/seedu/address/model/issue/IssueList.java
+++ b/src/main/java/seedu/address/model/issue/IssueList.java
@@ -104,7 +104,7 @@ public class IssueList implements Iterable<Issue> {
      * Checks if any issues have the given room associated with it
      *
      * @param target Room to check if it has issues associated with it.
-     * @return true if there are issues with the given room associated with it
+     * @return True if there are issues with the given room associated with it.
      */
     public boolean containsRoom(Room target) {
         return internalList.stream().anyMatch(issue ->

--- a/src/main/java/seedu/address/model/issue/IssueList.java
+++ b/src/main/java/seedu/address/model/issue/IssueList.java
@@ -10,10 +10,11 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.issue.exceptions.DuplicateIssueException;
 import seedu.address.model.issue.exceptions.IssueNotFoundException;
+import seedu.address.model.room.Room;
 
 /**
  * A list of issues that does not allow nulls.
- *
+ * <p>
  * Supports a minimal set of list operations.
  */
 public class IssueList implements Iterable<Issue> {
@@ -100,6 +101,17 @@ public class IssueList implements Iterable<Issue> {
     }
 
     /**
+     * Checks if any issues have the given room associated with it
+     *
+     * @param target Room to check if it has issues associated with it.
+     * @return true if there are issues with the given room associated with it
+     */
+    public boolean containsRoom(Room target) {
+        return internalList.stream().anyMatch(issue ->
+                issue.getRoomNumber().value.equals(target.getRoomNumber().roomNumber));
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Issue> asUnmodifiableObservableList() {
@@ -115,7 +127,7 @@ public class IssueList implements Iterable<Issue> {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof IssueList // instanceof handles nulls
-                        && internalList.equals(((IssueList) other).internalList));
+                && internalList.equals(((IssueList) other).internalList));
     }
 
     @Override

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -208,6 +208,11 @@ public class ModelStub implements Model {
     }
 
     @Override
+    public boolean issuesContainRoom(Room target) {
+        throw new AssertionError("This method should not be called.");
+    }
+
+    @Override
     public ObservableList<Issue> getFilteredIssueList() {
         throw new AssertionError("This method should not be called.");
     }

--- a/src/test/java/seedu/address/logic/commands/room/DeleteRoomCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/room/DeleteRoomCommandTest.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.logic.commands.room.RoomCommandTestUtil.showRoomAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 
 import org.junit.jupiter.api.Test;
@@ -28,8 +29,9 @@ public class DeleteRoomCommandTest {
 
     @Test
     public void execute_validIndexUnfilteredRoomList_success() {
-        Room roomToDelete = model.getFilteredRoomList().get(INDEX_FIRST.getZeroBased());
-        DeleteRoomCommand deleteRoomCommand = new DeleteRoomCommand(INDEX_FIRST);
+        // Use 4th as its not tied to any issues in the test data
+        Room roomToDelete = model.getFilteredRoomList().get(INDEX_FOURTH.getZeroBased());
+        DeleteRoomCommand deleteRoomCommand = new DeleteRoomCommand(INDEX_FOURTH);
 
         String expectedMessage = String.format(DeleteRoomCommand.MESSAGE_DELETE_ROOM_SUCCESS, roomToDelete);
 
@@ -49,7 +51,8 @@ public class DeleteRoomCommandTest {
 
     @Test
     public void execute_validIndexFilteredRoomList_success() {
-        showRoomAtIndex(model, INDEX_FIRST);
+        // Use 4th as its not tied to any issues in the test data
+        showRoomAtIndex(model, INDEX_FOURTH);
 
         Room roomToDelete = model.getFilteredRoomList().get(INDEX_FIRST.getZeroBased());
         DeleteRoomCommand deleteRoomCommand = new DeleteRoomCommand(INDEX_FIRST);

--- a/src/test/java/seedu/address/testutil/TypicalIndexes.java
+++ b/src/test/java/seedu/address/testutil/TypicalIndexes.java
@@ -9,4 +9,5 @@ public class TypicalIndexes {
     public static final Index INDEX_FIRST = Index.fromOneBased(1);
     public static final Index INDEX_SECOND = Index.fromOneBased(2);
     public static final Index INDEX_THIRD = Index.fromOneBased(3);
+    public static final Index INDEX_FOURTH = Index.fromOneBased(4);
 }

--- a/src/test/java/seedu/address/testutil/issue/TypicalIssues.java
+++ b/src/test/java/seedu/address/testutil/issue/TypicalIssues.java
@@ -7,20 +7,6 @@ import java.util.List;
 import seedu.address.model.issue.Issue;
 
 public class TypicalIssues {
-    public static final Issue ISSUE_10_100 = new IssueBuilder()
-            .withRoomNumber("10-100")
-            .withDescription("Broken table")
-            .withTimestamp("2021/01/01 12:00pm")
-            .withStatus("pending")
-            .withCategory("Furniture")
-            .build();
-    public static final Issue ISSUE_11_110 = new IssueBuilder()
-            .withRoomNumber("11-110")
-            .withDescription("Flickering light")
-            .withTimestamp("2021/03/20 8:35am")
-            .withStatus("closed")
-            .withCategory("Electrical")
-            .build();
     public static final Issue ISSUE_09_100 = new IssueBuilder()
             .withRoomNumber("09-100")
             .withDescription("Chair cylinder exploded")
@@ -34,6 +20,20 @@ public class TypicalIssues {
             .withTimestamp("2020/11/29 11:23pm")
             .withStatus("closed")
             .withCategory("Furniture")
+            .build();
+    public static final Issue ISSUE_10_100 = new IssueBuilder()
+            .withRoomNumber("10-100")
+            .withDescription("Broken table")
+            .withTimestamp("2021/01/01 12:00pm")
+            .withStatus("pending")
+            .withCategory("Furniture")
+            .build();
+    public static final Issue ISSUE_11_110 = new IssueBuilder()
+            .withRoomNumber("11-110")
+            .withDescription("Flickering light")
+            .withTimestamp("2021/03/20 8:35am")
+            .withStatus("closed")
+            .withCategory("Electrical")
             .build();
     public static final Issue ISSUE_12_110 = new IssueBuilder()
             .withRoomNumber("12-110")


### PR DESCRIPTION
### What this does
Closes #224 by blocking usage of odel unless all associated issues with it are deleted
- Fixes #146 

### How to test
1. Add a bunch of issues to a room
2. Try to delete the room. It should fail
3. Try to delete a room without issues. It should not fail
4. Do anything else to try and break this