### PR TITLE
Fix #310: Support alias and unalias commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/alias/AliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/alias/AliasCommand.java
@@ -69,6 +69,7 @@ public class AliasCommand extends Command {
 
         // update model
         model.addAlias(alias);
+        model.commitAddressBook();
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, alias.getAliasName()));
     }

--- a/src/main/java/seedu/address/logic/commands/alias/UnaliasCommand.java
+++ b/src/main/java/seedu/address/logic/commands/alias/UnaliasCommand.java
@@ -55,6 +55,7 @@ public class UnaliasCommand extends Command {
 
         //update model
         model.deleteAlias(aliasName);
+        model.commitAddressBook();
 
         return new CommandResult(String.format(MESSAGE_SUCCESS, aliasName));
     }


### PR DESCRIPTION
## What this does
Fixes #310 

## How to test
1. Launch SunRez
2. Create an alias. E.g. `alias a/rl cmd/rlist`
3. Test the alias `rl`
3. Undo the alias creation: `undo`
4. Test the alias again `rl`. The alias should not exist now.
5. Redo the alias creation `redo`
6. List the aliases: `aliases`
7. `rl = rlist` should be listed
8. Remove the alias: `unalias a/rl`
9. Test the alias `rl`. It should not exist.
10. Undo the deletion: `undo`
11. Test the alias `rl`. It should work.
12. Redo the deletion: `redo`
13. List the aliases: `aliases`. `rl = rlist` should not be there.