### PR TITLE
Fix: Change name to accept only alphabets

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -148,10 +148,9 @@ A keyword used in the various find commands.
 
 #### `NAME`
 The identifier of a resident.
-* Accepts only alphanumeric characters and spaces.
+* Accepts only alphabetic characters and spaces.
 * Must not be blank.
 * Must be unique.
-* For best usage, use English characters only.
 
 
 #### `PHONE_NUMBER`

--- a/src/main/java/seedu/address/model/resident/Name.java
+++ b/src/main/java/seedu/address/model/resident/Name.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Name implements Comparable<Name> {
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Names should only contain alphanumeric characters and spaces, and it should not be blank";
+            "Names should only contain alphabetic characters and spaces, and it should not be blank";
 
     /*
      * The first character of the address must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String VALIDATION_REGEX = "[\\p{Alpha}][\\p{Alpha} ]*";
 
     public final String fullName;
 

--- a/src/test/java/seedu/address/model/resident/NameTest.java
+++ b/src/test/java/seedu/address/model/resident/NameTest.java
@@ -32,9 +32,7 @@ public class NameTest {
 
         // valid name
         assertTrue(Name.isValidName("peter jack")); // alphabets only
-        assertTrue(Name.isValidName("12345")); // numbers only
-        assertTrue(Name.isValidName("peter the 2nd")); // alphanumeric characters
         assertTrue(Name.isValidName("Capital Tan")); // with capital letters
-        assertTrue(Name.isValidName("David Roger Jackson Ray Jr 2nd")); // long names
+        assertTrue(Name.isValidName("Capital Joe Tan ")); // with 3 words
     }
 }


### PR DESCRIPTION
Fixes #307 

### What this does 
Only validates alphabetic names.


### How to test: 
`radd n/John Doe 123 p/98765432 e/johnd@example.com y/1`
Expected message: `Names should only contain alphabetic characters and spaces, and it should not be blank`

