### PR TITLE
Prevent issues in the future

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -191,7 +192,7 @@ public class ParserUtil {
         return new IsOccupied(trimmedRoomOccupancyStatus);
     }
 
-    //==========Issue Parsing Method========================================================
+    // ==========Issue Parsing Method========================================================
 
     /**
      * Parses a {@code String roomNumber} into a {@code RoomNumber}.
@@ -235,6 +236,11 @@ public class ParserUtil {
         if (!Timestamp.isValidTimestamp(trimmedTimestamp)) {
             throw new ParseException(Timestamp.MESSAGE_CONSTRAINTS);
         }
+
+        LocalDateTime datetime = LocalDateTime.parse(trimmedTimestamp.toUpperCase(), Timestamp.FORMATTER);
+        if (datetime.compareTo(LocalDateTime.now()) > 0) {
+            throw new ParseException(Timestamp.MESSAGE_INVALID_FUTURE);
+        }
         return new Timestamp(trimmedTimestamp);
     }
 
@@ -271,12 +277,13 @@ public class ParserUtil {
         return new Category(trimmedCategory);
     }
 
-    //==========Alias Parsing Method========================================================
+    // ==========Alias Parsing Method========================================================
 
     /**
      * Parses a {@code String aliasName} and {@code String command} into a {@code Alias}.
+     *
      * @param aliasName name of the alias
-     * @param command content of the command
+     * @param command   content of the command
      * @throws ParseException if the inputs are invalid
      */
     public static Alias parseAlias(String aliasName, String command) throws ParseException {

--- a/src/main/java/seedu/address/model/issue/Timestamp.java
+++ b/src/main/java/seedu/address/model/issue/Timestamp.java
@@ -24,6 +24,8 @@ public class Timestamp implements Comparable<Timestamp> {
     public static final String MESSAGE_CONSTRAINTS = "Timestamps should be in the format "
             + TIMESTAMP_PATTERN + ", and it should not be blank";
 
+    public static final String MESSAGE_INVALID_FUTURE = "Timestamps should not be in the future";
+
     private static final Logger logger = LogsCenter.getLogger(Timestamp.class);
 
     public final LocalDateTime value;
@@ -52,7 +54,7 @@ public class Timestamp implements Comparable<Timestamp> {
      */
     public static boolean isValidTimestamp(String test) {
         try {
-            LocalDateTime.parse(test.toUpperCase(), FORMATTER);
+            LocalDateTime datetime = LocalDateTime.parse(test.toUpperCase(), FORMATTER);
             return true;
         } catch (DateTimeParseException dtpe) {
             logger.warning("Invalid timestamp given: " + dtpe.getMessage());


### PR DESCRIPTION
## What this does
Fixes #180 to prevent issues with future timestamps

## How to test
1. `iadd r/01-234 d/Something broke t/2030/1/1 12:00pm` should show "Timestamps should not be in the future"
2. `iadd r/01-234 d/Something broke t/2021/1/1 12:00pm` should work
3. `iadd r/01-234 d/Something broke` should work