### PR TITLE
Provide better timestamp help message

### DIFF
--- a/src/main/java/seedu/address/model/issue/Timestamp.java
+++ b/src/main/java/seedu/address/model/issue/Timestamp.java
@@ -22,7 +22,14 @@ public class Timestamp implements Comparable<Timestamp> {
     public static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern(TIMESTAMP_PATTERN, DEFAULT_LOCALE);
 
     public static final String MESSAGE_CONSTRAINTS = "Timestamps should be in the format "
-            + TIMESTAMP_PATTERN + ", and it should not be blank";
+            + TIMESTAMP_PATTERN + ", and it should not be blank\n\n"
+            + "yyyy - 4 digit year (e.g. 2021)\n"
+            + "M - 1 or 2 digit month (e.g. 1, 01, 12)\n"
+            + "d - 1 or 2 digit day (e.g. 1, 01, 31)\n"
+            + "h - hour (0-12)\n"
+            + "mm - minutes (0-59)\n"
+            + "a - case-insensitive AM/PM\n"
+            + "Example: 2021/1/1 1:00pm";
 
     private static final Logger logger = LogsCenter.getLogger(Timestamp.class);
 


### PR DESCRIPTION
## What this does
Fixes #214 to provide better timestamp help message

## How to test
1. `iadd r/01-234 d/Something broke t/abc` should show a help message detailing each component of a timestamp
2. `iadd r/01-234 d/Something broke t/2021/1/1 1:00pm` should work