### PR TITLE
Limit tag size to 25 chars

### DIFF
--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tag name should be alphanumeric and maximum 25 characters";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}{1,25}";
 
     public final String tagName;
 
@@ -36,7 +36,7 @@ public class Tag {
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof Tag // instanceof handles nulls
-                && tagName.equals(((Tag) other).tagName)); // state check
+                        && tagName.equals(((Tag) other).tagName)); // state check
     }
 
     @Override


### PR DESCRIPTION
## What this does
- Fixes #237 
- Fixes #328 
- Closes #284 
- by limiting tags to 25 characters

## How to test
1. run `oadd r/01-235 t/CORRIDOR_NON_AC g/abcdefghijklmnopqrstuvwxyz g/ValidTag`, it should fail and show the 25 character limit error message
2. run `oadd r/01-235 t/CORRIDOR_NON_AC g/abcdefghijklmnopqrstuvwxy g/ValidTag`, it should pass
3. run `oedit 2 g/abcdefghijklmnopqrstuvwxyz`, it should fail and show the 25 character limit error message
4. run `oedit 2 g/abcdefghijklmnopqrstuvwxy`, it should pass
5. run `iadd r/01-235 d/Room spawned suddenly g/abcdefghijklmnopqrstuvwxyz g/Mysterious`, it should fail and show the 25 character limit error message
6. run `iadd r/01-235 d/Room spawned suddenly g/abcdefghijklmnopqrstuvwxy g/Mysterious`, it should pass
7. run `iedit 2 g/abcdefghijklmnopqrstuvwxyz`, it should fail and show the 25 character limit error message
8. run `iedit 2 g/abcdefghijklmnopqrstuvwxy`, it should pass