### PR TITLE
Limit description characters

### DIFF
--- a/src/main/java/seedu/address/model/issue/Description.java
+++ b/src/main/java/seedu/address/model/issue/Description.java
@@ -10,13 +10,13 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class Description {
 
     public static final String MESSAGE_CONSTRAINTS = "Descriptions should only contain alphanumeric "
-            + "characters and spaces, and it should not be blank";
+            + "characters and spaces, and it should not be blank. Leading and trailing whitespaces will be trimmed.";
 
     /*
      * The first character of the description must not be a whitespace, otherwise
      * " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "\\S.*";
+    public static final String VALIDATION_REGEX = "[A-Za-z0-9][A-Za-z0-9 ]*";
 
     public final String value;
 

--- a/src/test/java/seedu/address/model/issue/DescriptionTest.java
+++ b/src/test/java/seedu/address/model/issue/DescriptionTest.java
@@ -32,8 +32,8 @@ public class DescriptionTest {
         assertTrue(Description.isValidDescription("1")); // single digit
         assertTrue(Description.isValidDescription("fdasf1212")); // alphanumberical
         assertTrue(Description.isValidDescription("jk23l1 j32k1 k2k21l df")); // alphanumerical with spaces
-        // [a-zA-Z0-9], special characters, and space
+        // All valid characters
         assertTrue(Description.isValidDescription(
-                "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUWXYZ1234567890~!@#$%^&*()_+`-=[];',./{}:\"<>?\\| "));
+                "ABCDEFGHIJKLMNOPQRSTUWXYZabcdefghijklmnopqrstuvwxyz1234567890 "));
     }
 }


### PR DESCRIPTION
## What this does
- Fixes #249 by limiting description to `[A-Za-z0-9][A-Za-z0-9 ]*`

## How to test
1. run `iadd r/01-234 d/ABCDEFGHIJKLMNOPQRSTUWXYZ abcdefghijklmnopqrstuvwxyz 1234567890`, it should work
2. run `iadd r/01-234 d/ABCDEFGHIJKLMNOPQRSTUWXYZ abcdefghijklmnopqrstuvwxyz 1234567890-` or any string with non alphanum and not space, should fail and show: 
>Descriptions should only contain alphanumeric characters and spaces, and it should not be blank. Leading and trailing whitespaces will be trimmed."
1. run `iedit 1 d/ABCDEFGHIJKLMNOPQRSTUWXYZ abcdefghijklmnopqrstuvwxyz 1234567890`, it should work
2. run `iadd 1 d/ABCDEFGHIJKLMNOPQRSTUWXYZ abcdefghijklmnopqrstuvwxyz 1234567890-` or any string with non alphanum and not space, should fail and show: 
>Descriptions should only contain alphanumeric characters and spaces, and it should not be blank. Leading and trailing whitespaces will be trimmed."