### PR TITLE
Update room number regex

### DIFF
--- a/src/main/java/seedu/address/model/issue/RoomNumber.java
+++ b/src/main/java/seedu/address/model/issue/RoomNumber.java
@@ -9,11 +9,10 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class RoomNumber {
 
-    public static final String MESSAGE_CONSTRAINTS = "Room numbers be of the format ##-###[-a] "
-            + "where # is a number and 'a' is an alphabet.";
+    public static final String MESSAGE_CONSTRAINTS = "Room numbers should be formatted as such: XY-ABC, "
+            + "where XY can be any pair of digits except 00, and ABC can be any 3 digits.";
 
-    // The room number follows the format ##-###[-a]
-    public static final String VALIDATION_REGEX = "[0-9]{2}-[0-9]{3}(-[A-F])*";
+    public static final String VALIDATION_REGEX = "(?!00)\\d{2}(-\\d{3})";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/issue/RoomNumber.java
+++ b/src/main/java/seedu/address/model/issue/RoomNumber.java
@@ -9,10 +9,9 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class RoomNumber {
 
-    public static final String MESSAGE_CONSTRAINTS = "Room numbers should be formatted as such: XY-ABC, "
-            + "where XY can be any pair of digits except 00, and ABC can be any 3 digits.";
+    public static final String MESSAGE_CONSTRAINTS = seedu.address.model.room.RoomNumber.MESSAGE_CONSTRAINTS;
 
-    public static final String VALIDATION_REGEX = "(?!00)\\d{2}(-\\d{3})";
+    public static final String VALIDATION_REGEX = seedu.address.model.room.RoomNumber.VALIDATION_REGEX;
 
     public final String value;
 


### PR DESCRIPTION
## What this does
- Updates the room number regex for issue to be the same as room
- Fixes #367 
- Fixes #366 

## How to test
1. Run `iadd r/00-000 d/desp`, it should show the error message "Room numbers should be formatted as such: XY-ABC, where XY can be any pair of digits except 00, and ABC can be any 3 digits."
2. Run `iadd r/01-234/ d/desp`, it should work