### PR TITLE
Fix(DG): Add manual testing instructions for rooms

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1040,6 +1040,34 @@ testers are expected to do more *exploratory* testing.
 
 3. _{ more test cases … }_
 
+### Rooms
+
+1. Adding a room
+
+    1. Prerequisites: There are no rooms in SunRez, or the room with the number `10-999` does not exist in the system.
+
+    2. Test case: `oadd r/10-999 t/suite_ac` <br>
+       Expected: A feedback message in the result box indicating the room was successfully added. The room should also be visible in the room panel.
+
+    3. Test case: `oadd r/10-999 t/suite_ac` <br>
+       Expected: An error message indicating the room `10-999` already exists in the system.
+
+    4. Test case: `oadd r/00-999 t/suite_ac` <br>
+        Expected: An error message indicating the value constraints for room number
+
+1. Deleting a room
+
+    1. Prerequisites: The room with the number `10-999` must exist in the system and its index must be known.
+
+    2. Test case: `odel [index of room 10-999]` <br>
+       Expected: A feedback message in the result box indicating the room was successfully deleted. The room should no longer be visible in the room panel.
+
+    3. Test case: `odel -5` <br>
+       Expected: An error message indicating that the index must be a non-zero unsigned integer.
+    
+    3. Test case: `odel abc` <br>
+       Expected: A message indicating the command format is invalid followed by proper usage instructions.
+
 
 ### Saving data
 


### PR DESCRIPTION
## What this does
This PR:
Closes #352 by adding manual test cases for `oadd` and `odel`

## How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Check that the DG has the changes listed above