### PR TITLE
Docs(UC): Update use cases for Alloc and Dealloc

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -920,8 +920,8 @@ Use case ends.
 
 1. User requests to list the residents.
 2. SunRez displays residents, each with its corresponding allocated room, if any.
-3. User requests to deallocate a resident from a room based on the index from the list displayed in step 2.
-4. SunRez deallocates the resident from room and saves the changes.
+3. User requests to deallocate a resident from its room.
+4. SunRez deallocates the resident from its room and saves the changes.
 
 **Extensions**
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -903,7 +903,7 @@ Use case ends.
 * 2a. There are no unassigned residents.
     
     Use case ends.
-* 3a. The given resident or room do not exist.
+* 3a. The given resident or room does not exist.
     * 3a1. SunRez shows an error message.   
       
         Use case resumes at step 2.
@@ -919,7 +919,7 @@ Use case ends.
 **MSS**
 
 1. User requests to list the residents.
-2. SunRez displays residents, each with its corresponding allocated room.
+2. SunRez displays residents, each with its corresponding allocated room, if any.
 3. User requests to deallocate a resident from a room based on the index from the list displayed in step 2.
 4. SunRez deallocates the resident from room and saves the changes.
 
@@ -928,7 +928,7 @@ Use case ends.
 * 2a. There are no assigned residents.
 
   Use case ends.
-* 3a. The given resident is does not exist.
+* 3a. The given resident does not exist.
     * 3a1. SunRez shows an error message.
 
       Use case resumes at step 2.

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -650,10 +650,7 @@ Use case ends.
     * 1a1. SunRez displays an error stating which field is incorrectly formatted and requests the user to try again after fixing the stated error.
     
         Use case ends.
-* 1b. The resident's phone number or email are in use by an existing resident.
-    * 1b1. SunRez displays an error stating which field is already in use and requests the user to try again after fixing the stated error.
     
-        Use case ends.
 * 2a. SunRez encounters an error while saving the content.
     * 2a1. SunRez shows an error message and requests the user to try their command again.
     
@@ -708,7 +705,7 @@ Use case ends.
 * 2a. The list of residents is empty.
     
     Use case ends.
-* 3a. The resident's details are invalid (e.g phone number/email/dob format does not conform, OR room number is invalid).
+* 3a. The resident's details are invalid (e.g phone number/email/year format does not conform).
     * 3a1. SunRez shows an error message stating which field is incorrectly formatted and requests the user to try again.
     
         Use case resumes at step 2.
@@ -896,19 +893,24 @@ Use case ends.
 
 **MSS**
 
-1. User requests to list unassigned residents and unallocated rooms.
-2. SunRez displays unassigned residents and unallocated rooms side-by-side.
-3. User requests to allocate a room to a resident.
-4. SunRez allocates the room and saves the changes.
+1. User requests to list unassigned residents.
+2. SunRez displays unassigned residents.
+3. User requests to allocate a resident to a room.
+4. SunRez allocates the resident to the room and saves the changes.
 
 **Extensions**
 
-* 2a. There are no unassigned residents or unassigned.
+* 2a. There are no unassigned residents.
     
     Use case ends.
-* 3a. The given index is invalid.
-    * 3a1. SunRez shows an error message.
+* 3a. The given resident or room do not exist.
+    * 3a1. SunRez shows an error message.   
+      
+        Use case resumes at step 2.
 
+* 3b. The given resident or room have already been assigned.
+    * 3b1. SunRez shows an error message. 
+      
         Use case resumes at step 2.
 
 
@@ -916,21 +918,25 @@ Use case ends.
 
 **MSS**
 
-1. User requests to list room allocations.
-2. SunRez displays rooms, each with its corresponding allocated resident.
-3. User requests to deallocate a room based on the index from the list displayed in step 2.
-4. SunRez deallocates the room and saves the changes.
+1. User requests to list the residents.
+2. SunRez displays residents, each with its corresponding allocated room.
+3. User requests to deallocate a resident from a room based on the index from the list displayed in step 2.
+4. SunRez deallocates the resident from room and saves the changes.
 
 **Extensions**
 
-* 2a. There are no unassigned residents or unassigned.
+* 2a. There are no assigned residents.
 
-    Use case ends.
-* 3a. The given index is invalid.
+  Use case ends.
+* 3a. The given resident is does not exist.
     * 3a1. SunRez shows an error message.
 
-        Use case resumes at step 2.
+      Use case resumes at step 2.
 
+* 3b. The given resident does not have an existing allocation.
+    * 3b1. SunRez shows an error message.
+        
+        Use Case resumes at step 2.
 
 ### UC-021 Access Command History
 


### PR DESCRIPTION
### What this does
Closes #353
Ensures that resident related use cases are updated. 

### How to test
cd to docs/ folder of the project.
Run bundle exec jekyll serve.
Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
Check that the DG has the changes listed above under the UC-19 and UC-20 section