### PR TITLE
Doc: Add Manual Testing 

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1079,11 +1079,17 @@ testers are expected to do more *exploratory* testing.
 6. Finding residents
     1. Prerequisites: There are a few residents. <br>
     2. Test case: `rfind KEYWORD` <br>
-       Expected: Residents' name with words fully matching `KEYWORD` are listed.  
-       
+       Expected: Residents' name with words fully matching `KEYWORD` are listed.
 
-
-### Allocation
+### Allocation and Deallocation
+1. Allocating residents to rooms
+    1. Prerequisites: Have 1 unallocated resident and 1 unallocated room displayed. 
+    2. Test case: `alloc ri/1 oi/1` <br>
+       Expected: 1st resident is allocated to the 1st room displayed in the list.
+2. Deallocating residents
+    1. Prerequisites: There is at least 1 resident allocated displayed. <br>
+    2. Test case: `dealloc 1` <br>
+       Expected: 1st resident is deallocated from the room.
 
 ### Saving data
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1062,11 +1062,11 @@ starting point for testers to work on; testers are expected to do more *explorat
 
 ### Allocation and Deallocation
 1. Allocating residents to rooms
-    1. Prerequisites: Have 1 unallocated resident and 1 unallocated room displayed.
+    1. Prerequisites: Have the first displayed resident and fist displayed room be both unallocated.
     2. Test case: `alloc ri/1 oi/1` <br>
        Expected: 1st resident is allocated to the 1st room displayed in the list.
 2. Deallocating residents
-    1. Prerequisites: There is at least 1 resident that is allocated displayed. <br>
+    1. Prerequisites: Have the first displayed resident be both allocated. <br>
     2. Test case: `dealloc 1` <br>
        Expected: 1st resident is deallocated from the room.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1021,17 +1021,17 @@ starting point for testers to work on; testers are expected to do more *explorat
 
 ### Resident Data
 1. Adding residents
-
-    1. Test case: `radd n/John Doe p/98765432 e/johnd@example.com y/1` <br>
+    1. Prerequisites: There is no existing resident named `John Doe`. 
+    2. Test case: `radd n/John Doe p/98765432 e/johnd@example.com y/1` <br>
        Expected: Resident is added.
-    2. Incorrect `radd` commands to try. <br>
+    3. Incorrect `radd` commands to try. <br>
        `radd n/John 123 p/98765432 e/johnd@example.com y/1`, where name is wrong. <br>
        `radd n/John Doe p/9876abcd e/johnd@example.com y/1`, where phone number is wrong. <br>
        `radd n/John Doe p/98765432 e/johndexample.com y/1`, where email is wrong. <br>
        `radd n/John Doe p/98765432 e/johnd@example.com y/7`, where year is wrong. <br>
        Expected: An error message indicating the problem is shown, and how to rectify it.
 2. Editing residents
-    1. Prerequisites: There is at least 1 resident displayed. <br>
+    1. Prerequisites: There is at least 1 resident displayed and no existing resident named `Jane Doe` <br>
     1. Test case: `redit 1 n/Jane Doe` <br>
        Expected: Resident in first index is edited.
     2. Incorrect `redit` commands to try. <br>
@@ -1040,9 +1040,9 @@ starting point for testers to work on; testers are expected to do more *explorat
        `redit 1 n/John 122`, where name format is wrong. <br>
        Expected: An error message indicating the problem is shown, and how to rectify it.
 3. Deleting residents
-    1. Prerequisites: There is at least 1 resident displayed. <br>
+    1. Prerequisites: There is at least 1 resident displayed and the resident is not allocated to any room. <br>
     2. Test case: `rdel 1` <br>
-       Expected: Resident in first index is edited.
+       Expected: Resident in first index is deleted.
     3. Incorrect `rdel` commands to try. <br>
        `rdel 0`, where index is wrong. <br>
        `rdel X`, where X is an index that is out of bounds. <br>
@@ -1052,13 +1052,13 @@ starting point for testers to work on; testers are expected to do more *explorat
     2. Test case: `rlist` <br>
        Expected: All residents are listed.
 5. Listing unallocated residents
-    1. Prerequisites: There is at least 1 resident displayed and the resident is unallocated to a room. <br>
+    1. Prerequisites: At least 1 resident exists and the resident is unallocated to a room. <br>
     2. Test case: `rulist` <br>
-       Expected: Unallocated residents are listed.
+       Expected: All unallocated residents are listed.
 6. Finding residents
     1. Prerequisites: There are a few residents. <br>
     2. Test case: `rfind KEYWORD` <br>
-       Expected: Residents' name with words fully matching `KEYWORD` are listed.
+       Expected: Residents whose names have words fully matching `KEYWORD` are listed.
 
 ### Allocation and Deallocation
 1. Allocating residents to rooms
@@ -1066,7 +1066,7 @@ starting point for testers to work on; testers are expected to do more *explorat
     2. Test case: `alloc ri/1 oi/1` <br>
        Expected: 1st resident is allocated to the 1st room displayed in the list.
 2. Deallocating residents
-    1. Prerequisites: There is at least 1 resident allocated displayed. <br>
+    1. Prerequisites: There is at least 1 resident that is allocated displayed. <br>
     2. Test case: `dealloc 1` <br>
        Expected: 1st resident is deallocated from the room.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1062,11 +1062,11 @@ starting point for testers to work on; testers are expected to do more *explorat
 
 ### Allocation and Deallocation
 1. Allocating residents to rooms
-    1. Prerequisites: Have the first displayed resident and first displayed room be both unallocated.
+    1. Prerequisites: The first displayed resident and first displayed room are both unallocated.
     2. Test case: `alloc ri/1 oi/1` <br>
        Expected: 1st resident is allocated to the 1st room displayed in the list.
 2. Deallocating residents
-    1. Prerequisites: Have the first displayed resident be both allocated. <br>
+    1. Prerequisites: The first displayed resident is allocated. <br>
     2. Test case: `dealloc 1` <br>
        Expected: 1st resident is deallocated from the room.
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1040,6 +1040,50 @@ testers are expected to do more *exploratory* testing.
 
 3. _{ more test cases … }_
 
+### Resident Data
+1. Adding residents
+   
+   1. Test case: `radd n/John Doe p/98765432 e/johnd@example.com y/1` <br>
+      Expected: Resident is added.
+   2. Incorrect `radd` commands to try. <br>
+      `radd n/John 123 p/98765432 e/johnd@example.com y/1`, where name is wrong. <br>
+      `radd n/John Doe p/9876abcd e/johnd@example.com y/1`, where phone number is wrong. <br>
+      `radd n/John Doe p/98765432 e/johndexample.com y/1`, where email is wrong. <br>
+      `radd n/John Doe p/98765432 e/johnd@example.com y/7`, where year is wrong. <br>
+      Expected: An error message indicating the problem is shown, and how to rectify it. 
+2. Editing residents 
+    1. Prerequisites: There is at least 1 resident displayed. <br>
+    1. Test case: `redit 1 n/Jane Doe` <br>
+       Expected: Resident in first index is edited.
+    2. Incorrect `redit` commands to try. <br>
+       `redit ab n/Jane Doe`, where index is wrong. <br>
+       `redit X n/Jane Doe`, where X is an index that is out of bounds. <br>
+       `redit 1 n/John 122`, where name format is wrong. <br>
+       Expected: An error message indicating the problem is shown, and how to rectify it.
+3. Deleting residents
+    1. Prerequisites: There is at least 1 resident displayed. <br>
+    2. Test case: `rdel 1` <br>
+       Expected: Resident in first index is edited.
+    3. Incorrect `rdel` commands to try. <br>
+         `rdel 0`, where index is wrong. <br>
+         `rdel X`, where X is an index that is out of bounds. <br>
+         Expected: An error message indicating the problem is shown, and how to rectify it.
+4. Listing residents
+    1. Prerequisites: There are residents to be listed. <br>
+    2. Test case: `rlist` <br>
+        Expected: All residents are listed.
+5. Listing unallocated residents
+    1. Prerequisites: There is at least 1 resident displayed and the resident is unallocated to a room. <br>
+    2. Test case: `rulist` <br>
+       Expected: Unallocated residents are listed.
+6. Finding residents
+    1. Prerequisites: There are a few residents. <br>
+    2. Test case: `rfind KEYWORD` <br>
+       Expected: Residents' name with words fully matching `KEYWORD` are listed.  
+       
+
+
+### Allocation
 
 ### Saving data
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -1062,7 +1062,7 @@ starting point for testers to work on; testers are expected to do more *explorat
 
 ### Allocation and Deallocation
 1. Allocating residents to rooms
-    1. Prerequisites: Have the first displayed resident and fist displayed room be both unallocated.
+    1. Prerequisites: Have the first displayed resident and first displayed room be both unallocated.
     2. Test case: `alloc ri/1 oi/1` <br>
        Expected: 1st resident is allocated to the 1st room displayed in the list.
 2. Deallocating residents


### PR DESCRIPTION
Closes #350 

### What this does
Adds manual testing guide to Developer Guide for residents

### How to test
cd to docs/ folder of the project.
Run bundle exec jekyll serve.
Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
Check that the DG has the changes listed above