### PR TITLE
Fix(Room): Block editing rooms with associated issues

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -316,7 +316,12 @@ Format: `oedit INDEX [r/ROOM_NUMBER] [t/ROOM_TYPE] [g/TAG]`
 * The occupancy status is not controllable through the `oedit` command.
 * Room occupancy status can only be changed through the `alloc` or `dealloc` command when a resident is allocated or deallocated. 
   See [allocate a resident](#allocate-resident-to-room-alloc) or [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info.
+* `oedit` will be blocked if there are issues tagged to the room. Run `idel` to [delete the issues](#delete-an-issue--idel) associated with the room before making further edits.
+    * This is done to prevent issues from being assigned to nonexistent rooms, by editing away a room's number after assigning an issue to it
 
+<div markdown="block" class="alert alert-info">
+:information_source: Room numbers are editable as renovation or re-numbering excercises may take place.
+</div>
 
 Parameters:
 * [INDEX](#index) The index of the room to edit.

--- a/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
+++ b/src/main/java/seedu/address/logic/commands/room/EditRoomCommand.java
@@ -48,6 +48,8 @@ public class EditRoomCommand extends Command {
     public static final String MESSAGE_DUPLICATE_ROOM = "This room already exists in SunRez.";
     public static final String MESSAGE_ROOM_ALLOCATED_FAILURE =
             "The room has already been allocated to another resident. Please deallocate the room before editing.";
+    public static final String MESSAGE_ROOM_HAS_ISSUES = "This room still has issues assigned to it. Please delete all "
+            + "corresponding issues before editing the room.";
 
     private final Index index;
     private final EditRoomDescriptor editRoomDescriptor;
@@ -82,6 +84,10 @@ public class EditRoomCommand extends Command {
 
         if (model.hasEitherResidentRoom(new ResidentRoom(null, roomToEdit.getRoomNumber()))) {
             throw new CommandException(MESSAGE_ROOM_ALLOCATED_FAILURE);
+        }
+
+        if (model.issuesContainRoom(roomToEdit)) {
+            throw new CommandException(MESSAGE_ROOM_HAS_ISSUES);
         }
 
         model.setRoom(roomToEdit, editedRoom);

--- a/src/test/java/seedu/address/logic/commands/room/EditRoomCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/room/EditRoomCommandTest.java
@@ -12,6 +12,7 @@ import static seedu.address.logic.commands.room.RoomCommandTestUtil.VALID_ROOM_T
 import static seedu.address.logic.commands.room.RoomCommandTestUtil.showRoomAtIndex;
 import static seedu.address.testutil.TypicalAddressBook.getTypicalAddressBook;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FOURTH;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND;
 
 import org.junit.jupiter.api.Test;
@@ -35,16 +36,17 @@ public class EditRoomCommandTest {
 
     @Test
     public void execute_allFieldsSpecifiedUnfilteredRoomList_success() {
-        Room roomToEdit = model.getFilteredRoomList().get(0);
+        Room roomToEdit = model.getFilteredRoomList().get(3);
 
         // Room we are changing to needs to maintain the occupancy status
         // of the room we start with. So we pre-set it here.
         Room editedRoom = new RoomBuilder()
-                // .withOccupancyStatus(roomToEdit.isOccupied().toString())
+                .withOccupancyStatus(roomToEdit.isOccupied().toString())
                 .build();
 
         EditRoomDescriptor descriptor = new EditRoomDescriptorBuilder(editedRoom).build();
-        EditRoomCommand editRoomCommand = new EditRoomCommand(INDEX_FIRST, descriptor);
+        // Use 4th as its not tied to any issues in the test data
+        EditRoomCommand editRoomCommand = new EditRoomCommand(INDEX_FOURTH, descriptor);
 
         String expectedMessage = String.format(EditRoomCommand.MESSAGE_EDIT_ROOM_SUCCESS, editedRoom);
 
@@ -56,13 +58,17 @@ public class EditRoomCommandTest {
 
     @Test
     public void execute_someFieldsSpecifiedUnfilteredRoomList_success() {
-        Index indexLastRoom = Index.fromOneBased(model.getFilteredRoomList().size());
-        Room lastRoom = model.getFilteredRoomList().get(indexLastRoom.getZeroBased());
+        // We used second-last room as last room is tied to an issue
+        Index indexSecondLastRoom = Index.fromOneBased(model.getFilteredRoomList().size() - 1);
+        Room secondLastRoom = model.getFilteredRoomList().get(indexSecondLastRoom.getZeroBased());
 
-        RoomBuilder roomInList = new RoomBuilder(lastRoom);
+        RoomBuilder roomInList = new RoomBuilder(secondLastRoom);
+
+        // Inherit the occupancy status of the room we start with, as that is guaranteed
         Room editedRoom = roomInList
                 .withRoomNumber(VALID_ROOM_NUMBER_ONE)
                 .withRoomType(VALID_ROOM_TYPES.get(0))
+                .withOccupancyStatus(secondLastRoom.isOccupied().toString())
                 .build();
 
         EditRoomDescriptor descriptor = new EditRoomDescriptorBuilder()
@@ -70,21 +76,22 @@ public class EditRoomCommandTest {
                 .withRoomType(VALID_ROOM_TYPES.get(0))
                 .build();
 
-        EditRoomCommand editRoomCommand = new EditRoomCommand(indexLastRoom, descriptor);
+        EditRoomCommand editRoomCommand = new EditRoomCommand(indexSecondLastRoom, descriptor);
 
         String expectedMessage = String.format(EditRoomCommand.MESSAGE_EDIT_ROOM_SUCCESS, editedRoom);
 
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
-        expectedModel.setRoom(lastRoom, editedRoom);
+        expectedModel.setRoom(secondLastRoom, editedRoom);
 
         assertCommandSuccess(editRoomCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_noFieldSpecifiedUnfilteredRoomList_success() {
-        EditRoomCommand editRoomCommand = new EditRoomCommand(INDEX_FIRST,
+        // Use 4th as its not tied to any issues in the test data
+        EditRoomCommand editRoomCommand = new EditRoomCommand(INDEX_FOURTH,
                 new EditRoomDescriptor());
-        Room editedRoom = model.getFilteredRoomList().get(INDEX_FIRST.getZeroBased());
+        Room editedRoom = model.getFilteredRoomList().get(INDEX_FOURTH.getZeroBased());
 
         String expectedMessage = String.format(EditRoomCommand.MESSAGE_EDIT_ROOM_SUCCESS, editedRoom);
 
@@ -95,8 +102,10 @@ public class EditRoomCommandTest {
 
     @Test
     public void execute_filteredList_success() {
-        showRoomAtIndex(model, INDEX_FIRST);
+        // Use 4th room as it is not tied to any issues.
+        showRoomAtIndex(model, INDEX_FOURTH);
 
+        // Use 4th as its not tied to any issues in the test data
         Room roomInFilteredList = model.getFilteredRoomList().get(INDEX_FIRST.getZeroBased());
         Room editedRoom = new RoomBuilder(roomInFilteredList).withRoomNumber(VALID_ROOM_NUMBER_ONE).build();
         EditRoomDescriptor descriptor = new EditRoomDescriptorBuilder().withRoomNumber(VALID_ROOM_NUMBER_ONE).build();


### PR DESCRIPTION
## What this does
This PR:
1. Closes #387 blocking the editing of rooms that have associated issues

## How to test
1. Run SunRez with the sample data
2. Try editing or deleting a room that is tied to an issue. It should fail
3. Delete the issue and try editing the room again. It should succeed.
4. Recreate the instructions in #387 and it should also fail