### PR TITLE
Fix: Prevent getRandomEntry from generating an empty string

### DIFF
--- a/src/test/java/seedu/address/testutil/TypicalCommandHistoryEntries.java
+++ b/src/test/java/seedu/address/testutil/TypicalCommandHistoryEntries.java
@@ -51,7 +51,7 @@ public class TypicalCommandHistoryEntries {
         final int rightLimit = 122; // letter 'z'
 
         final Random random = new Random();
-        final int targetStringLength = random.nextInt(maxStringLength + 1);
+        final int targetStringLength = random.nextInt(maxStringLength) + 1;
 
         final String generatedString = random.ints(leftLimit, rightLimit + 1)
                 .filter(i -> (i <= 57 || i >= 65) && (i <= 90 || i >= 97))


### PR DESCRIPTION
## What this does
This PR should fix the test case `PlainTextCommandHistoryStorageTest#saveAndRead_allInOrder_success` from occasionally failing.

## How to test
Not deterministic, but see if this test case fails randomly either locally or during automated tests on GitHub.