### PR TITLE
Docs(DG): Add logic class diagram note

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -119,6 +119,13 @@ For example, the `Logic` component (see the class diagram given below) defines i
 
 ![Class Diagram of the Logic Component](images/LogicClassDiagram.png)
 
+<div markdown="span" class="alert alert-info">
+:information_source: **Diagram note:** <br>
+
+`XYZCommand` and `XYZCommandParser` are placeholder classes. See the diagram notes in the 
+[Logic component section](#logic-component) for more information.
+</div>
+
 **How the architecture components interact with each other**
 
 The *Sequence Diagram* below shows how the components interact with each other for the scenario where the user issues the command `rdel 1`.


### PR DESCRIPTION
## What this does
Adds a diagram note to the Logic class diagram located in the architecture section of the DG, describing the placeholder classes.

## How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Check that the DG has the changes listed above