### PR TITLE
Fix(UG): Standarise use of INDEX and fix typos

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -369,8 +369,7 @@ Examples:
 Edits the existing room record at a specified index.
 
 Format: `oedit INDEX [r/ROOM_NUMBER] [t/ROOM_TYPE] [g/TAG]`
-* `INDEX` refers to the index number shown in the displayed room list. 
-  `INDEX` **must be a positive integer 1, 2, 3, …**.
+* `INDEX` refers to the index number shown in the displayed room list.
 * At least one of the optional fields must be provided.
 * Existing values will be updated to the input values.
 * `oedit` will block editing of a room number **if the room is occupied**. Run `dealloc` to deallocate the room before 
@@ -405,8 +404,7 @@ Example:
 Deletes the room at a specified index.
 
 Format: `odel INDEX`
-* `INDEX` refers to the index number shown in the displayed resident list. 
-  `INDEX` **must be a positive integer 1,2,3, ...**.
+* `INDEX` refers to the index number shown in the displayed room list.
 * `odel` will be blocked if the room is occupied. Run `dealloc` to deallocate the room before attempting to delete the room.
   See [deallocate a resident](#deallocate-resident-from-room-dealloc) for more info.
 * `odel` will be blocked if the there are issues associated with the room.


### PR DESCRIPTION
## What this does
This PR:
1. Closes #430 by removing extraneous qualifications of `INDEX`
2. Fixes a typo where I referred to a room list as a resident list

## How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Check that the UG has the changes listed above