### PR TITLE
Docs(Favicon): Fix favicon in PPPs

### DIFF
--- a/docs/_includes/head.html
+++ b/docs/_includes/head.html
@@ -5,6 +5,7 @@
 
   <link rel="stylesheet" href="{{ "/assets/css/style.css" | relative_url }}">
   <link rel="shortcut icon" type="image/png" href="favicon.png">
+  <link rel="shortcut icon" type="image/png" href="../favicon.png">
 
   {%- include custom-head.html -%}
 


### PR DESCRIPTION
## What this does
This PR fixes the favicon to show up in everyone's PPPs.

## How to test
1. cd to `docs/` folder of the project.
2. Run `bundle exec jekyll serve`.
3. Open the jekyll-hosted website in your browser (default address: http://127.0.0.1:4000).
4. Go to `About Us` then click on the `portfolio` links for each team member. The favicon should show up.